### PR TITLE
fix: 모든 페이지 관련 부분에서 화살표로 이동 시 1페이지에 접근이 불가합니다

### DIFF
--- a/apps/web/src/components/Pagination.tsx
+++ b/apps/web/src/components/Pagination.tsx
@@ -13,7 +13,7 @@ function Pagination(props: { currentPage: number; onSetPage: (page: number) => v
 
   return (
     <PaginationContainer>
-      <button disabled={!props.prevPage} onClick={() => props.prevPage && props.onSetPage(props.prevPage)}>
+      <button disabled={props.prevPage === null} onClick={() => props.onSetPage(props.prevPage || 0)}>
         <svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="8" width="4" height="4" fill="#141414" />
           <rect x="4" y="4" width="4" height="4" fill="#141414" />


### PR DESCRIPTION
# 💡 기능
- `모든 페이지 관련 부분에서 화살표로 이동 시 1페이지에 접근이 불가합니다 `이슈 수정
- closed #41 
- prevPage가 0일경우 Boolean 값으로 false로 판별되어 button이 disabled된 문제, null 값만 disabled 하도록 변경
# 🔎 기타
