### PR TITLE
refactor: styled global style to panda css global css

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,1 +1,46 @@
 @layer reset, base, tokens, recipes, utilities;
+
+@layer reset {
+  @font-face {
+    font-family: 'DNFBitBitv2';
+    font-style: normal;
+    font-weight: 700;
+    src: url('//cdn.df.nexon.com/img/common/font/DNFBitBitv2.otf') format('opentype');
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: 'DNFBitBitv2';
+    font-style: normal;
+    font-weight: 400;
+    line-height: 140%; /* 107.8px */
+    background-color: #2a7442;
+    position: relative;
+  }
+
+  button {
+    cursor: pointer;
+    border: transparent;
+    background-color: transparent;
+    font-family: 'DNFBitBitv2';
+    line-height: 1.5;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 140%;
+    padding: 0;
+  }
+
+  input {
+    font-family: 'DNFBitBitv2';
+
+    &::placeholder {
+      color: #b5b5b5;
+      font-family: 'DNFBitBitv2';
+    }
+  }
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -37,10 +37,10 @@
 
   input {
     font-family: 'DNFBitBitv2';
+  }
 
-    &::placeholder {
-      color: #b5b5b5;
-      font-family: 'DNFBitBitv2';
-    }
+  input::placeholder {
+    color: #b5b5b5;
+    font-family: 'DNFBitBitv2';
   }
 }

--- a/apps/web/src/styles/GlobalStyle.tsx
+++ b/apps/web/src/styles/GlobalStyle.tsx
@@ -4,47 +4,6 @@ import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
 
-  @font-face {
-    font-family:'DNFBitBitv2';
-    font-style: normal;
-    font-weight: 700;
-    src: url('//cdn.df.nexon.com/img/common/font/DNFBitBitv2.otf')format('opentype')
-  }
-
-  *, *::before, *::after {
-    box-sizing: border-box;
-  }
-
-  body {
-    font-family: 'DNFBitBitv2';
-    font-style: normal;
-    font-weight: 400;
-    line-height: 140%; /* 107.8px */
-    background-color: #2A7442;
-    position: relative;
-  }
-
-  button {
-    cursor: pointer;
-    border: transparent;
-    background-color: transparent;  
-    font-family: 'DNFBitBitv2';
-    line-height: 1.5;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 140%; 
-    padding: 0;
-  }
-
-  input {
-    font-family: 'DNFBitBitv2';
-
-    &::placeholder {
-      color: #b5b5b5;
-      font-family: 'DNFBitBitv2';
-    
-    }
-  }
  
 `;
 


### PR DESCRIPTION
# 💡 기능
- global style이 styled component 쪽에 선언되어있어, panda css로 버튼 등 스타일을 입혀도 우선순위에서 밀리는 문제가 있었어요. 
- styled-component는 점차 제거해갈 예정이며, panda css로 마이그레이션 할 예정이므로 
- panda css에 맞도록 global reset style을 적용하였습니다. 

# 🔎 기타
참고 : https://github.com/chakra-ui/panda/blob/05899a30765662c6b0b5d2585cca03fbf4f789be/website/styles/panda.css#L19-L27