### PR TITLE
feat: mobile condition 추가

### DIFF
--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
       textStyles,
     },
   },
+  conditions: {
+    extend: {
+      mobile: '@media (max-width: 768px)',
+    },
+  },
 
   syntax: 'object-literal',
   jsxFramework: 'react',


### PR DESCRIPTION
# 💡 기능
- mobile 반응형을 위한 panda css condition을 추가하였습니다. 
- 사용은 아래 코드와 같이 사용하면 됩니다. 

사용 예시
```ts
const sliderContainerStyle = css({
  position: 'relative',
  width: '1120px',
  height: '800px',
  _mobile: {
    width: 'calc(100vw - 40px)',
    height: 'auto',
  },
});

```
