### PR TITLE
[Landing Renewal] Pet Slider Mobile, Plugin 사용 방식으로 변경

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,11 +14,12 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@egjs/flicking-plugins": "^4.7.1",
     "@egjs/react-flicking": "^4.11.3",
     "@gitanimals/api": "workspace:*",
+    "@gitanimals/asset-font": "workspace:*",
     "@gitanimals/exception": "workspace:*",
     "@gitanimals/ui-panda": "workspace:*",
-    "@gitanimals/asset-font": "workspace:*",
     "@tanstack/react-query": "^5.32.0",
     "axios": "^1.6.8",
     "framer-motion": "^11.1.7",

--- a/apps/web/src/app/landing/AvailablePetSection/AnimalSlider.style.ts
+++ b/apps/web/src/app/landing/AvailablePetSection/AnimalSlider.style.ts
@@ -69,4 +69,21 @@ export const cardContainerMobile = grid({
   width: '265px',
   height: '325px',
   padding: '0 1px',
+
+  // 0.75배
+
+  '@media (max-width: 400px)': {
+    width: '200px',
+    height: '244px',
+
+    '& .animal-card-info': {
+      bottom: '10px',
+    },
+    '& .animal-card-type': {
+      textStyle: 'glyph18.bold',
+    },
+    '& .animal-card-rating': {
+      textStyle: 'glyph16.regular',
+    },
+  },
 });

--- a/apps/web/src/app/landing/AvailablePetSection/AnimalSlider.tsx
+++ b/apps/web/src/app/landing/AvailablePetSection/AnimalSlider.tsx
@@ -1,5 +1,3 @@
-import { css, cx } from '_panda/css';
-
 import { AnimalCard } from '@/components/AnimalCard';
 
 import * as styles from './AnimalSlider.style';
@@ -165,16 +163,7 @@ function AnimalSlider() {
           })}
         </AnimalSliderContainer>
       </div>
-      <div
-        className={cx(
-          styles.showMobile,
-          css({
-            '& .animal-card-container': {
-              transition: 'transform 0.5s, z-index 0.1s, opacity 1s',
-            },
-          }),
-        )}
-      >
+      <div className={styles.showMobile}>
         <AnimalSliderContainerMobile>
           {ANIMAL_LIST.map((animalList: Animal, idx) => {
             return (

--- a/apps/web/src/app/landing/AvailablePetSection/AnimalSliderContainerMobile.tsx
+++ b/apps/web/src/app/landing/AvailablePetSection/AnimalSliderContainerMobile.tsx
@@ -5,7 +5,7 @@ import { useRef } from 'react';
 import Image from 'next/image';
 import { css, cx } from '_panda/css';
 import { Fade, Perspective } from '@egjs/flicking-plugins';
-import type { ChangedEvent, FlickingOptions, FlickingProps, MoveEvent, Panel, ReadyEvent } from '@egjs/react-flicking';
+import type { ChangedEvent, FlickingOptions, FlickingProps } from '@egjs/react-flicking';
 import Flicking from '@egjs/react-flicking';
 
 import { sliderContainer } from '../MainSlider/MainSlider.style';
@@ -40,34 +40,20 @@ function AnimalSliderContainerMobile({ children }: { children: React.ReactNode }
   const onPanelChanged = (e: ChangedEvent<Flicking>) => {
     setCurrentPanelIndex(e.index);
   };
+  const _plugins = [new Perspective({ rotate: 0.5, scale: 0.2 }), new Fade()];
 
   const sliderOptions: Partial<FlickingProps & FlickingOptions> = {
     onChanged: onPanelChanged,
     align: 'center',
+    plugins: _plugins,
   };
 
-  const updateTransform = (e: MoveEvent<Flicking> | ReadyEvent<Flicking>) => {
-    e.currentTarget.panels.forEach((panel: Panel) => {
-      const progress = Math.abs(panel.progress);
-      const scale = 0.8 + 0.2 * (1 - progress);
-      const translateX = panel.progress === 0 ? 0 : panel.progress > 0 ? `${-20 * progress}vw` : `${20 * progress}vw`;
-
-      const isActivePanel = progress < 0.8;
-
-      panel.element.style.transform = `scale(${scale}) translateX(${translateX})`;
-      panel.element.style.zIndex = isActivePanel ? '10' : '1';
-      panel.element.style.opacity = isActivePanel ? '1' : '0.4';
-      panel.element.style.transition = isActivePanel ? '' : 'opacity 0.3s';
-    });
-  };
-
-  const _plugins = [new Perspective({ rotate: 0.5, scale: 0.2 }), new Fade()];
   return (
     <div>
       <div className={sliderContainer}>
         <ArrowButton onClick={moveToPrevPanel} direction="prev" disabled={isFirstPanel} />
         <ArrowButton onClick={moveToNextPanel} direction="next" disabled={isLastPanel} />
-        <Flicking ref={flicking} {...sliderOptions} plugins={_plugins}>
+        <Flicking ref={flicking} {...sliderOptions}>
           {children}
         </Flicking>
       </div>

--- a/apps/web/src/app/landing/AvailablePetSection/AnimalSliderContainerMobile.tsx
+++ b/apps/web/src/app/landing/AvailablePetSection/AnimalSliderContainerMobile.tsx
@@ -4,6 +4,7 @@ import React, { Children, useState } from 'react';
 import { useRef } from 'react';
 import Image from 'next/image';
 import { css, cx } from '_panda/css';
+import { Fade, Perspective } from '@egjs/flicking-plugins';
 import type { ChangedEvent, FlickingOptions, FlickingProps, MoveEvent, Panel, ReadyEvent } from '@egjs/react-flicking';
 import Flicking from '@egjs/react-flicking';
 
@@ -60,12 +61,13 @@ function AnimalSliderContainerMobile({ children }: { children: React.ReactNode }
     });
   };
 
+  const _plugins = [new Perspective({ rotate: 0.5, scale: 0.2 }), new Fade()];
   return (
     <div>
       <div className={sliderContainer}>
         <ArrowButton onClick={moveToPrevPanel} direction="prev" disabled={isFirstPanel} />
         <ArrowButton onClick={moveToNextPanel} direction="next" disabled={isLastPanel} />
-        <Flicking ref={flicking} {...sliderOptions} onMove={updateTransform} onReady={updateTransform}>
+        <Flicking ref={flicking} {...sliderOptions} plugins={_plugins}>
           {children}
         </Flicking>
       </div>

--- a/apps/web/src/components/AnimalCard/AnimalCard.tsx
+++ b/apps/web/src/components/AnimalCard/AnimalCard.tsx
@@ -28,9 +28,9 @@ function AnimalCard(props: AnimalCardProps) {
       <picture className={styles.thumbnailImage}>
         <Image src={getPersonaImage(props.type)} alt={props.type} width={233} height={233} />
       </picture>
-      <div className={styles.infoWrapper}>
-        <p className={styles.typeText}>{getAnimalTypeLabel(props.type)}</p>
-        <p className={styles.ratingText}>{props.dropRate}</p>
+      <div className={cx('animal-card-info', styles.infoWrapper)}>
+        <p className={cx('animal-card-type', styles.typeText)}>{getAnimalTypeLabel(props.type)}</p>
+        <p className={cx('animal-card-rating', styles.ratingText)}>{props.dropRate}</p>
       </div>
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@egjs/flicking-plugins':
+        specifier: ^4.7.1
+        version: 4.7.1(@egjs/flicking@4.11.3)
       '@egjs/react-flicking':
         specifier: ^4.11.3
         version: 4.11.3
@@ -1140,6 +1143,11 @@ packages:
 
   '@egjs/component@3.0.5':
     resolution: {integrity: sha512-cLcGizTrrUNA2EYE3MBmEDt2tQv1joVP1Q3oDisZ5nw0MZDx2kcgEXM+/kZpfa/PAkFvYVhRUZwytIQWoN3V/w==}
+
+  '@egjs/flicking-plugins@4.7.1':
+    resolution: {integrity: sha512-J0k499sCs5IAMXAJuBcrY1OoiHRi4BPbS1/RCCkIzsYgdoHzcAUjKyhSsms3gLz4O/K5eTbBmWBUtFO86fETHg==}
+    peerDependencies:
+      '@egjs/flicking': ^4.1.0
 
   '@egjs/flicking@4.11.3':
     resolution: {integrity: sha512-90IbXMwdiNL4+Yrvfgi4zYk9XKLbjVaVLus5lIl28twQiT/KV3W9ypJOJEK7U5U9oS2q7dn8OJZolD8JNOsxag==}
@@ -8166,6 +8174,10 @@ snapshots:
       '@egjs/component': 3.0.5
 
   '@egjs/component@3.0.5': {}
+
+  '@egjs/flicking-plugins@4.7.1(@egjs/flicking@4.11.3)':
+    dependencies:
+      '@egjs/flicking': 4.11.3
 
   '@egjs/flicking@4.11.3':
     dependencies:


### PR DESCRIPTION
# 💡 기능
- 기존에 이런 plugin이 있는지 모르고 생으로 구현하였습니다. 
- plugin을 사용한 방식으로 변경해, 오류가 적어진(?) 방식으로 변경되었습니다. 
- 디자인과는 조금 다른데, @Youna-Ha 애게 컨펌 받아서 괜찮습니다!

# 🔎 기타
이후로 해보고싶은거 & 해야하는거
- mobile, pc slider 나누지 않고 하나로하기 
- 슬라이더 한 컴포넌트로 사용하고 props로 나머지 옵션들 넘겨서 사용하기
- Arrow Plugin 사용하기
- 화면 크기가 바뀌면 slider 다시 렌더링하기