### PR TITLE
[Landing Renewal] Slider Arrow Plugin 추가 - 도움도움 !

### DIFF
--- a/apps/web/src/app/landing/AvailablePetSection/AnimalSliderContainer.tsx
+++ b/apps/web/src/app/landing/AvailablePetSection/AnimalSliderContainer.tsx
@@ -1,63 +1,106 @@
 'use client';
 
-import React, { Children, useState } from 'react';
+import React, { useState } from 'react';
 import { useRef } from 'react';
 import Image from 'next/image';
 import { css, cx } from '_panda/css';
+import { Arrow } from '@egjs/flicking-plugins';
 import type { ChangedEvent, FlickingOptions, FlickingProps } from '@egjs/react-flicking';
-import Flicking from '@egjs/react-flicking';
+import Flicking, { ViewportSlot } from '@egjs/react-flicking';
 
 // TODO: 후에 공통으로 사용할 수 있을 것 같다.
 function AnimalSliderContainer({ children }: { children: React.ReactNode }) {
   const flicking = useRef<Flicking | null>(null);
+  // const [plugins, setPlugins] = useState<Plugin[]>([]); // NOTE: 사용한다면 type 유의, fliking type 써야함
 
   const [currentPanelIndex, setCurrentPanelIndex] = useState(0);
 
-  const isFirstPanel = currentPanelIndex === 0;
-  const isLastPanel = Children.count(children) - 1 === currentPanelIndex;
+  // const isFirstPanel = currentPanelIndex === 0;
+  // const isLastPanel = Children.count(children) - 1 === currentPanelIndex;
 
-  const moveToNextPanel = async () => {
-    if (!flicking.current) return;
-    if (isLastPanel) return;
-    if (flicking.current.animating) return;
-
-    try {
-      flicking.current.next();
-    } catch (error) {}
-  };
-
-  const moveToPrevPanel = async () => {
-    if (!flicking.current) return;
-    if (isFirstPanel) return;
-    if (flicking.current.animating) return;
-
-    try {
-      flicking.current.prev();
-    } catch (error) {}
-  };
   const onPanelChanged = (e: ChangedEvent<Flicking>) => {
     setCurrentPanelIndex(e.index);
   };
 
+  const plugins = [new Arrow({})];
+
+  // NOTE: dom 로드 후 플러그인을 넣으면 나을까 싶었음
+  // useEffect(() => {
+  //   if (!flicking.current) return;
+  //   const arrowPlugin = new Arrow({
+  //     prevElSelector: '.flicking-arrow-prev',
+  //     nextElSelector: '.flicking-arrow-next',
+  //   });
+
+  //   setPlugins([arrowPlugin]);
+  // }, [flicking]);
+
   const sliderOptions: Partial<FlickingProps & FlickingOptions> = {
     panelsPerView: 1,
     onChanged: onPanelChanged,
+    plugins,
   };
 
   return (
     <div>
       <div className={sliderContainer}>
-        <ArrowButton onClick={moveToPrevPanel} direction="prev" disabled={isFirstPanel} />
-        <ArrowButton onClick={moveToNextPanel} direction="next" disabled={isLastPanel} />
         <Flicking ref={flicking} {...sliderOptions}>
           {children}
+          <ViewportSlot>
+            <span className={cx('flicking-arrow-prev', 'is-outside', sliderArrowStyle, prevArrowStyle)}>
+              <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
+            </span>
+            <span className={cx('flicking-arrow-next', 'is-outside', sliderArrowStyle, nextArrowStyle)}>
+              <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
+            </span>
+          </ViewportSlot>
         </Flicking>
+        {/* <span className={cx('flicking-arrow-prev', 'is-outside', sliderArrowStyle, prevArrowStyle)}>
+          <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
+        </span>
+        <span className={cx('flicking-arrow-next', 'is-outside', sliderArrowStyle, nextArrowStyle)}>
+          <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
+        </span> */}
       </div>
     </div>
   );
 }
 
 export default AnimalSliderContainer;
+
+const sliderArrowStyle = css({
+  width: '40px',
+  backgroundColor: 'yellow',
+  position: 'absolute',
+  display: 'block',
+  height: '40px',
+  top: '0',
+  bottom: 0,
+  margin: 'auto',
+  zIndex: 100,
+
+  '&.flicking-arrow-disabled': {
+    cursor: 'not-allowed',
+    width: '36px',
+    height: '36px',
+    filter: 'brightness(0.5)',
+  },
+});
+
+const prevArrowStyle = css({
+  rotate: '180deg',
+  left: '-62px',
+  _mobile: {
+    left: '8px',
+  },
+});
+
+const nextArrowStyle = css({
+  right: '-62px',
+  _mobile: {
+    right: '8px',
+  },
+});
 
 const sliderContainer = css({
   position: 'relative',
@@ -69,74 +112,74 @@ const sliderContainer = css({
   },
 });
 
-function ArrowButton({
-  onClick,
-  direction,
-  disabled,
-}: {
-  onClick: () => void;
-  direction: 'prev' | 'next';
-  disabled: boolean;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={cx(
-        direction === 'prev' ? prevArrowStyle : nextArrowStyle,
-        css({
-          rotate: direction === 'prev' ? '180deg' : '0deg',
-          cursor: disabled ? 'not-allowed' : 'pointer',
-          width: disabled ? '36px' : '40px',
-          height: disabled ? '36px' : '40px',
-          _mobile: {
-            width: disabled ? '24px' : '26px',
-            height: disabled ? '24px' : '26px',
-          },
-        }),
-      )}
-    >
-      {disabled ? (
-        <Image src="/icon/circle-arrow-disable.svg" alt="arrow" width={36} height={36} />
-      ) : (
-        <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
-      )}
-    </button>
-  );
-}
+// function ArrowButton({
+//   onClick,
+//   direction,
+//   disabled,
+// }: {
+//   onClick: () => void;
+//   direction: 'prev' | 'next';
+//   disabled: boolean;
+// }) {
+//   return (
+//     <button
+//       onClick={onClick}
+//       className={cx(
+//         direction === 'prev' ? prevArrowStyle : nextArrowStyle,
+//         css({
+//           rotate: direction === 'prev' ? '180deg' : '0deg',
+//           cursor: disabled ? 'not-allowed' : 'pointer',
+//           width: disabled ? '36px' : '40px',
+//           height: disabled ? '36px' : '40px',
+//           _mobile: {
+//             width: disabled ? '24px' : '26px',
+//             height: disabled ? '24px' : '26px',
+//           },
+//         }),
+//       )}
+//     >
+//       {disabled ? (
+//         <Image src="/icon/circle-arrow-disable.svg" alt="arrow" width={36} height={36} />
+//       ) : (
+//         <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
+//       )}
+//     </button>
+//   );
+// }
 
-const arrowStyle = css({
-  position: 'absolute',
-  top: '0',
-  bottom: '0',
-  margin: 'auto',
-  zIndex: '2', // TODO : zIndex theme 적용
+// const arrowStyle = css({
+//   position: 'absolute',
+//   top: '0',
+//   bottom: '0',
+//   margin: 'auto',
+//   zIndex: '2', // TODO : zIndex theme 적용
 
-  '& img': {
-    width: '100%',
-    height: '100%',
-  },
+//   '& img': {
+//     width: '100%',
+//     height: '100%',
+//   },
 
-  _mobile: {
-    bottom: '191px',
-  },
-});
+//   _mobile: {
+//     bottom: '191px',
+//   },
+// });
 
-const prevArrowStyle = cx(
-  arrowStyle,
-  css({
-    left: '-62px',
-    _mobile: {
-      left: '8px',
-    },
-  }),
-);
+// // const prevArrowStyle = cx(
+// //   arrowStyle,
+// //   css({
+// //     left: '-62px',
+// //     _mobile: {
+// //       left: '8px',
+// //     },
+// //   }),
+// // );
 
-const nextArrowStyle = cx(
-  arrowStyle,
-  css({
-    right: '-62px',
-    _mobile: {
-      right: '8px',
-    },
-  }),
-);
+// const nextArrowStyle = cx(
+//   arrowStyle,
+//   css({
+//     right: '-62px',
+//     _mobile: {
+//       right: '8px',
+//     },
+//   }),
+// );

--- a/apps/web/src/app/landing/AvailablePetSection/AnimalSliderContainer.tsx
+++ b/apps/web/src/app/landing/AvailablePetSection/AnimalSliderContainer.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRef } from 'react';
 import Image from 'next/image';
 import { css, cx } from '_panda/css';
 import { Arrow } from '@egjs/flicking-plugins';
 import type { ChangedEvent, FlickingOptions, FlickingProps } from '@egjs/react-flicking';
-import Flicking, { ViewportSlot } from '@egjs/react-flicking';
+import Flicking from '@egjs/react-flicking';
 
 // TODO: 후에 공통으로 사용할 수 있을 것 같다.
 function AnimalSliderContainer({ children }: { children: React.ReactNode }) {
@@ -22,7 +22,11 @@ function AnimalSliderContainer({ children }: { children: React.ReactNode }) {
     setCurrentPanelIndex(e.index);
   };
 
-  const plugins = [new Arrow({})];
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => setIsMounted(true), []);
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const plugins = [new Arrow({ parentEl: wrapperRef.current })];
 
   // NOTE: dom 로드 후 플러그인을 넣으면 나을까 싶었음
   // useEffect(() => {
@@ -38,29 +42,29 @@ function AnimalSliderContainer({ children }: { children: React.ReactNode }) {
   const sliderOptions: Partial<FlickingProps & FlickingOptions> = {
     panelsPerView: 1,
     onChanged: onPanelChanged,
-    plugins,
+    plugins: isMounted ? plugins : undefined,
   };
 
   return (
     <div>
-      <div className={sliderContainer}>
+      <div ref={wrapperRef} className={sliderContainer}>
         <Flicking ref={flicking} {...sliderOptions}>
           {children}
-          <ViewportSlot>
+          {/* <ViewportSlot>
             <span className={cx('flicking-arrow-prev', 'is-outside', sliderArrowStyle, prevArrowStyle)}>
               <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
             </span>
             <span className={cx('flicking-arrow-next', 'is-outside', sliderArrowStyle, nextArrowStyle)}>
               <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
             </span>
-          </ViewportSlot>
+          </ViewportSlot> */}
         </Flicking>
-        {/* <span className={cx('flicking-arrow-prev', 'is-outside', sliderArrowStyle, prevArrowStyle)}>
+        <span className={cx('flicking-arrow-prev', 'is-outside', sliderArrowStyle, prevArrowStyle)}>
           <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
         </span>
         <span className={cx('flicking-arrow-next', 'is-outside', sliderArrowStyle, nextArrowStyle)}>
           <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
-        </span> */}
+        </span>
       </div>
     </div>
   );
@@ -89,7 +93,8 @@ const sliderArrowStyle = css({
 
 const prevArrowStyle = css({
   rotate: '180deg',
-  left: '-62px',
+  // left: '-62px',
+  transform: 'translateX(40px)',
   _mobile: {
     left: '8px',
   },


### PR DESCRIPTION
# 💡 기능
- Arrow Plugin을 사용한 방식으로 변경하고 싶어요. 
- 현재 수정하고 있는 부분은 `AnimalSliderContainer.tsx` 파일로 Pet Slider 부분 PC 버전에 해당하는 부분입니다. (디자인 상 화살표가 슬라이드 외부에 있음)
- PC 버전의 경우 Arrow 버튼이 슬라이드 외부에 있어요. 그런데 Arrow Plugin 방식을 사용하면서 슬라이드 외부에 두는 방식이 해결이 안되네요

#### 이렇게 쓰면 슬라이더 내부에 Arrow가 생깁니다 -> 슬라이드 외부로 위치만을 이동시키면 `overflow: hidden`으로 인해 가려져요ㅅㄴ
```ts
 <div className={sliderContainer}>
        <Flicking ref={flicking} {...sliderOptions}>
          {children}
          <ViewportSlot>
            <span className={cx('flicking-arrow-prev', 'is-outside', sliderArrowStyle, prevArrowStyle)}>
              <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
            </span>
            <span className={cx('flicking-arrow-next', 'is-outside', sliderArrowStyle, nextArrowStyle)}>
              <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
            </span>
          </ViewportSlot>
        </Flicking>
      </div>

 ```
      
 #### 이렇게 쓰고싶어요 
Flicking 공식문서에는 아래와 같이 사용하는 방법도 소개하고있습니다. 
그런데,,, 이렇게 사용하면 오류가 나며 페이지가 터지는 상태예요 
어떻게 해결할 수 있을까요? 
      
```ts
<div className={sliderContainer}>
        <Flicking ref={flicking} {...sliderOptions}>
          {children}
        </Flicking>
        <span className={cx('flicking-arrow-prev', 'is-outside', sliderArrowStyle, prevArrowStyle)}>
          <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
        </span>
        <span className={cx('flicking-arrow-next', 'is-outside', sliderArrowStyle, nextArrowStyle)}>
          <Image src="/icon/circle-arrow.svg" alt="arrow" width={40} height={40} />
        </span>
      </div>
```
# 🔎 기타
- 참고 링크 : https://naver.github.io/egjs-flicking/ko/Plugins#options-3