### PR TITLE
간단한 meta title 추가

### DIFF
--- a/apps/web/src/app/dev/page.tsx
+++ b/apps/web/src/app/dev/page.tsx
@@ -1,9 +1,14 @@
 'use client';
 
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Center } from '_panda/jsx';
 import { Button } from '@gitanimals/ui-panda';
 import { sendGTMEvent } from '@next/third-parties/google';
+
+export const metadata: Metadata = {
+  title: 'GitAnimals | Dev',
+};
 
 function DevPage() {
   return (

--- a/apps/web/src/app/jwt/layout.tsx
+++ b/apps/web/src/app/jwt/layout.tsx
@@ -1,4 +1,9 @@
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'GitAnimals | Login',
+};
 
 export default function JWTLayout({ children }: { children: React.ReactNode }) {
   return <Suspense>{children}</Suspense>;

--- a/apps/web/src/app/jwt/page.tsx
+++ b/apps/web/src/app/jwt/page.tsx
@@ -7,11 +7,6 @@ import styled from 'styled-components';
 import { checkUsedCouponsByToken } from '@/apis/user/getUsedCoupons';
 import { useLogin } from '@/store/user';
 
-export const metadata: Metadata = {
-  title: '...',
-  description: '...',
-};
-
 function JWTPage() {
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/apps/web/src/app/jwt/page.tsx
+++ b/apps/web/src/app/jwt/page.tsx
@@ -7,6 +7,11 @@ import styled from 'styled-components';
 import { checkUsedCouponsByToken } from '@/apis/user/getUsedCoupons';
 import { useLogin } from '@/store/user';
 
+export const metadata: Metadata = {
+  title: '...',
+  description: '...',
+};
+
 function JWTPage() {
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { Suspense, useState } from 'react';
+import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import styled from 'styled-components';
 
@@ -14,6 +15,10 @@ import OneType from './OneType';
 const LazyProfileSection = dynamic(() => import('./ProfileSection'), { ssr: false });
 
 type ChooseType = '1-type' | 'farm-type';
+
+export const metadata: Metadata = {
+  title: 'GitAnimals | Mypage',
+};
 
 function Mypage() {
   const [selectedType, setSelectedType] = useState<ChooseType>('1-type');

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,9 +1,15 @@
 'use client';
 
+import type { Metadata } from 'next';
+
 import Header from '@/components/Layout/Header';
 import Layout from '@/components/Layout/Layout';
 
 import Welcome from './Welcome';
+
+export const metadata: Metadata = {
+  title: 'GitAnimals | Home',
+};
 
 export default function Home() {
   return (

--- a/apps/web/src/app/prepare/page.tsx
+++ b/apps/web/src/app/prepare/page.tsx
@@ -1,11 +1,13 @@
-'use client';
-
-import React from 'react';
+import type { Metadata } from 'next';
 import styled from 'styled-components';
 
 import Button from '@/components/Button';
 import Header from '@/components/Layout/Header';
 import Layout from '@/components/Layout/Layout';
+
+export const metadata: Metadata = {
+  title: 'GitAnimals | Prepare',
+};
 
 function PreparePage() {
   return (

--- a/apps/web/src/app/shop/layout.tsx
+++ b/apps/web/src/app/shop/layout.tsx
@@ -1,4 +1,9 @@
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'GitAnimals | Shop',
+};
 
 export default function ShopLayout({ children }: { children: React.ReactNode }) {
   return <Suspense>{children}</Suspense>;

--- a/apps/web/src/app/start/page.tsx
+++ b/apps/web/src/app/start/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import type { Metadata } from 'next';
 import { useRouter } from 'next/navigation';
 import styled from 'styled-components';
 
@@ -10,6 +11,10 @@ import Header from '@/components/Layout/Header';
 import Layout from '@/components/Layout/Layout';
 import SelectAnimals from '@/components/SelectAnimals';
 import { COUPON_CODE } from '@/constants/coupon';
+
+export const metadata: Metadata = {
+  title: 'GitAnimals | Start',
+};
 
 function StartPage() {
   const router = useRouter();

--- a/apps/web/src/components/Layout/Header.tsx
+++ b/apps/web/src/components/Layout/Header.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable jsx-a11y/anchor-is-valid */


### PR DESCRIPTION
# 💡 기능
- 리뉴얼 전 기존 페이지에서 meta title을 페이지 마다 다르게 해두지 않아, 어떤 페이지를 많이 들어가는지 체크가 어려웠어요. 
- 리뉴얼 하기전 동안에도 트래킹 할 수 있게 간단하게 meta title 추가하였습니다. 
# 🔎 기타
