### PR TITLE
[Landing Renewal] Next/image Error fix (withBundleAnalyzer 제거)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,5 +1,5 @@
-import withBundleAnalyzer from '@next/bundle-analyzer';
-withBundleAnalyzer({ enabled: process.env.ANALYZE === 'true' });
+// import withBundleAnalyzer from '@next/bundle-analyzer';
+// withBundleAnalyzer({ enabled: process.env.ANALYZE === 'true' });
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -20,4 +20,5 @@ const nextConfig = {
   },
 };
 
-export default withBundleAnalyzer(nextConfig);
+export default nextConfig;
+// export default withBundleAnalyzer(nextConfig);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
     <div>
       <MainSection />
       {/* image error로 인해 잠시 주석 처리 @hyesungoh */}
-      {/* <AvailablePetSection /> */}
+      <AvailablePetSection />
       <HavePetWaySection />
       <ChoosePetSection />
       <Footer />


### PR DESCRIPTION
# 💡 기능
- `import withBundleAnalyzer from '@next/bundle-analyzer';`기능을 추가하면서 next/image를 가져오지 못하는 문제가 있었습니다. 
- 단순히 `next/image`를 사용하지 못하는 문제가 아니라, next.config.mjs 자체가 잘 읽히지 않는것 같아. 추가하신 라이브러리 사용을 주석처리해두었습니다. 
- 이후에 문제없이 동작하게 될 때 다시 추가하는것이 좋을 것 같아요. 
# 🔎 기타
![image](https://github.com/user-attachments/assets/405bd756-bd4e-44e3-b0cf-2f5af14185c9)
위위의 오류가 발생하는 이유와 동일한 이슈일 것 같아요. 
