### PR TITLE
feat: 로그인 시에 header에 'Redirect-When-Success'추가

### DIFF
--- a/apps/web/src/app/api/oauth/route.ts
+++ b/apps/web/src/app/api/oauth/route.ts
@@ -1,0 +1,9 @@
+export async function GET() {
+  const res = await fetch('https://api.gitanimals.org/logins/oauth/github', {
+    headers: {
+      'Redirect-When-Success': process.env.NODE_ENV === 'production' ? 'HOME' : 'LOCAL',
+    },
+  });
+
+  return Response.json({ url: res.url });
+}

--- a/apps/web/src/app/auth/layout.tsx
+++ b/apps/web/src/app/auth/layout.tsx
@@ -1,0 +1,5 @@
+import { Suspense } from 'react';
+
+export default function JWTLayout({ children }: { children: React.ReactNode }) {
+  return <Suspense>{children}</Suspense>;
+}

--- a/apps/web/src/app/auth/page.tsx
+++ b/apps/web/src/app/auth/page.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import { checkUsedCouponsByToken } from '@/apis/user/getUsedCoupons';
 import { useLogin } from '@/store/user';
 
-// TODO: 삭제 예정
 function JWTPage() {
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/apps/web/src/components/LoginButton.tsx
+++ b/apps/web/src/components/LoginButton.tsx
@@ -1,7 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 
-import { GITHUB_OAUTH_REQUEST_URL } from '@/constants/oauth';
 import { useUser } from '@/store/user';
 
 interface LoginButtonProps {}
@@ -9,13 +8,16 @@ interface LoginButtonProps {}
 function LoginButton({ children }: PropsWithChildren<LoginButtonProps>) {
   const { isLogin } = useUser();
 
+  const onLogin = async () => {
+    const res = await fetch('/api/oauth');
+    const data = await res.json();
+
+    window.location.assign(data.url);
+  };
+
   if (isLogin) return children;
 
-  return (
-    <a href={GITHUB_OAUTH_REQUEST_URL} onClick={(e) => e.stopPropagation()}>
-      {children}
-    </a>
-  );
+  return <button onClick={onLogin}>{children}</button>;
 }
 
 export default LoginButton;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12707,9 +12707,9 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-import-attributes@1.9.5(acorn@8.10.0):
+  acorn-import-attributes@1.9.5(acorn@8.11.3):
     dependencies:
-      acorn: 8.10.0
+      acorn: 8.11.3
 
   acorn-jsx@5.3.2(acorn@7.4.1):
     dependencies:
@@ -18425,8 +18425,8 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.10.0
-      acorn-import-attributes: 1.9.5(acorn@8.10.0)
+      acorn: 8.11.3
+      acorn-import-attributes: 1.9.5(acorn@8.11.3)
       browserslist: 4.23.1
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.17.0


### PR DESCRIPTION
# 💡 기능
- header에 'Redirect-When-Success' 값을 추가하도록 API가 변경되었어요. `LOCAL` 또는 `HOME`
- header에 값을 넣어 보내기 위해 a 태그가 아니라 fetch or axios 요청이 필요했어요
- 단순히 해당 경로에 fetch 요청을 하면, CORS가 발생해
- next server를 이용해 api를 만들어 header를 추가해 API 요청을 한 후, 결과값을 client로 받아 리디렉션 하도록 하였어요. 
# 🔎 기타
