### PR TITLE
refactor: octokit hanlder api 추가 & 사용

### DIFF
--- a/apps/web/src/apis/github/core.ts
+++ b/apps/web/src/apis/github/core.ts
@@ -2,6 +2,23 @@ import { Octokit } from '@octokit/core';
 
 const ISSUE_TOKEN = process.env.NEXT_PUBLIC_ISSUE_TOKEN;
 
-export const octokit = new Octokit({
+const octokit = new Octokit({
   auth: ISSUE_TOKEN,
 });
+
+const OCTOKIT_BASE_INFO = {
+  owner: 'git-good-w',
+  repo: 'gitanimals',
+  headers: {
+    'X-GitHub-Api-Version': '2022-11-28',
+  },
+} as const;
+
+export const requestOctokit = async (method: 'GET' | 'POST', url: string, data?: object) => {
+  const response = await octokit.request(`${method} ${url}`, {
+    ...OCTOKIT_BASE_INFO,
+    ...data,
+  });
+
+  return response.data;
+};

--- a/apps/web/src/apis/github/useCreateComment.ts
+++ b/apps/web/src/apis/github/useCreateComment.ts
@@ -1,4 +1,4 @@
-import { octokit } from './core';
+import { requestOctokit } from './core';
 
 export interface CreateCommentRequest {
   issueNumber: number;
@@ -6,13 +6,8 @@ export interface CreateCommentRequest {
 }
 
 export async function createComment(request: CreateCommentRequest) {
-  return await octokit.request(`POST /repos/git-goods/gitanimals/issues/${request.issueNumber}/comments`, {
-    owner: 'git-good-w',
-    repo: 'gitanimals',
+  return requestOctokit('POST', `/repos/git-goods/gitanimals/issues/${request.issueNumber}/comments`, {
     issue_number: request.issueNumber,
     body: request.body,
-    headers: {
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
   });
 }

--- a/apps/web/src/apis/github/usePostIssue.ts
+++ b/apps/web/src/apis/github/usePostIssue.ts
@@ -1,7 +1,7 @@
 import type { UseMutationOptions } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 
-import { octokit } from './core';
+import { requestOctokit } from './core';
 
 export interface PostIssueRequest {
   title: string;
@@ -18,19 +18,12 @@ interface PostIssueResponse {
 }
 
 export async function postIssue(request: PostIssueRequest): Promise<PostIssueResponse> {
-  const response = await octokit.request('POST /repos/git-goods/gitanimals/issues', {
-    owner: 'git-good-w',
-    repo: 'gitanimals',
+  return requestOctokit('POST', '/repos/git-goods/gitanimals/issues', {
     title: request.title,
     body: request.body,
     assignees: request.assignees,
     labels: request.labels,
-    headers: {
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
   });
-
-  return response.data;
 }
 
 export const usePostIssue = (options?: UseMutationOptions<PostIssueResponse, unknown, PostIssueRequest>) =>


### PR DESCRIPTION
# 💡 기능
- `requestOctokit` 라는 octokit handler api를 추가하고 이를 공통적으로 사용하도록 변경하였습니다.
- octokit을 사용할 때 넘기는 기본적인 정보 `owner`, `repo`, `header`등의 정보를 공통적으로 포함하는 것을 의도하였습니다. 
- 추가적으로 api를 호출할 때 method와 url을 나누어 어떤 작업인지 명시할 수 있도록 하였습니다. 
# 🔎 기타
