### PR TITLE
모바일 GNB 추가

### DIFF
--- a/apps/web/messages/en_US.json
+++ b/apps/web/messages/en_US.json
@@ -6,7 +6,8 @@
     "login": "Login",
     "logout": "Logout",
     "github": "Github",
-    "dev": "Dev"
+    "dev": "Dev",
+    "language": "Language"
   },
   "HomePage": {
     "title": "Hello world!",

--- a/apps/web/messages/en_US.json
+++ b/apps/web/messages/en_US.json
@@ -2,6 +2,7 @@
   "Layout": {
     "mypage": "MyPage",
     "auction": "Auction",
+    "shop": "Shop",
     "login": "Login",
     "logout": "Logout",
     "github": "Github",

--- a/apps/web/messages/ko_KR.json
+++ b/apps/web/messages/ko_KR.json
@@ -5,6 +5,7 @@
     "login": "Login",
     "logout": "Logout",
     "github": "Github",
+    "shop": "Shop",
     "dev": "Dev"
   },
   "HomePage": {

--- a/apps/web/messages/ko_KR.json
+++ b/apps/web/messages/ko_KR.json
@@ -1,12 +1,13 @@
 {
   "Layout": {
-    "mypage": "MyPage",
-    "auction": "Auction",
-    "login": "Login",
-    "logout": "Logout",
+    "mypage": "마이페이지",
+    "auction": "상점",
+    "login": "로그인",
+    "logout": "로그아웃",
     "github": "Github",
-    "shop": "Shop",
-    "dev": "Dev"
+    "shop": "상점",
+    "dev": "Dev",
+    "language": "언어"
   },
   "HomePage": {
     "title": "Hello world!",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "@chromatic-com/storybook": "^1.3.3",
     "@gitanimals/eslint-config": "workspace:*",
     "@gitanimals/typescript-config": "workspace:*",
+    "@gitanimals/util-common": "workspace:*",
     "@next/bundle-analyzer": "^14.2.5",
     "@pandacss/dev": "^0.41.0",
     "@storybook/addon-essentials": "^8.0.9",

--- a/apps/web/src/components/AdaptiveLink.tsx
+++ b/apps/web/src/components/AdaptiveLink.tsx
@@ -1,0 +1,26 @@
+import type { AnchorHTMLAttributes } from 'react';
+import { isExternalLink } from '@gitanimals/util-common';
+
+import { Link } from '@/i18n/routing';
+
+/**
+ * 제공된 href에 따라 외부 링크를 위한 <a> 태그 또는 내부 경로를 위한 Next.js <Link> 컴포넌트를 렌더링
+ */
+export const AdaptiveLink = ({
+  href,
+  children,
+  ...rest
+}: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => {
+  if (isExternalLink(href)) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} {...rest}>
+      {children}
+    </Link>
+  );
+};

--- a/apps/web/src/components/Layout/DesktopGNB.tsx
+++ b/apps/web/src/components/Layout/DesktopGNB.tsx
@@ -6,6 +6,7 @@ import { center, flex } from '_panda/patterns';
 import { ChevronRightIcon } from 'lucide-react';
 
 import { getServerAuth } from '@/auth';
+import { AdaptiveLink } from '@/components/AdaptiveLink';
 import { checkIdDevAccessPossible } from '@/utils/dev';
 
 import { LoginOutBtn } from './LoginOutBtn';
@@ -13,6 +14,7 @@ import type { NavMenu } from './menu.constants';
 import { LOGIN_NAV_MENU_LIST, NON_LOGIN_NAV_MENU_LIST } from './menu.constants';
 
 export async function DesktopGNB() {
+  const t = await getTranslations('Layout');
   const session = await getServerAuth();
 
   const isLogin = Boolean(session);
@@ -31,10 +33,12 @@ export async function DesktopGNB() {
                 </li> */}
             {isLogin && LOGIN_NAV_MENU_LIST.map((item) => <NavMenuItem key={item.label} item={item} />)}
             {NON_LOGIN_NAV_MENU_LIST.map((item) => (
-              <NavMenuItem key={item.label} item={item} />
+              <NavMenuItem key={t(item.label)} item={item} />
             ))}
             <DevMenu />
-            <LoginOutBtn />
+            <li>
+              <LoginOutBtn />
+            </li>
           </ul>
 
           {session && (
@@ -58,16 +62,9 @@ export async function DesktopGNB() {
 }
 
 async function NavMenuItem({ item }: { item: NavMenu }) {
-  const t = await getTranslations('Layout');
   return (
     <li>
-      {item.isExternal ? (
-        <a target="_blank" href={item.href}>
-          {t(item.label)}
-        </a>
-      ) : (
-        <Link href={item.href}>{t(item.label)}</Link>
-      )}
+      <AdaptiveLink href={item.href}>{item.label}</AdaptiveLink>
     </li>
   );
 }
@@ -75,7 +72,7 @@ async function NavMenuItem({ item }: { item: NavMenu }) {
 const headerBaseStyle = flex({
   justifyContent: 'space-between',
   alignItems: 'center',
-  zIndex: 100,
+  zIndex: 2000,
   position: 'fixed',
   padding: '0 20px',
   top: 0,

--- a/apps/web/src/components/Layout/GNB.tsx
+++ b/apps/web/src/components/Layout/GNB.tsx
@@ -1,9 +1,10 @@
 import { DesktopGNB } from './DesktopGNB';
+import { MobileGNB } from './MobileGNB';
 
 async function GNB() {
   return (
     <>
-      {/* <MobileGNB /> */}
+      <MobileGNB />
       <DesktopGNB />
     </>
   );

--- a/apps/web/src/components/Layout/LanguageSelector.tsx
+++ b/apps/web/src/components/Layout/LanguageSelector.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { css, cx } from '_panda/css';
 import { RadioButtonOff, RadioButtonOn } from '@gitanimals/ui-icon';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -83,6 +83,7 @@ const dropdownStyles = css({
 export function MobileLanguageSelector({ onBack }: { onBack: () => void }) {
   const pathname = usePathname();
   const locale = useLocale();
+  const t = useTranslations('Layout');
 
   return (
     <article className={languageSelectorContainerStyle}>
@@ -91,7 +92,7 @@ export function MobileLanguageSelector({ onBack }: { onBack: () => void }) {
           <ChevronLeft size={24} color="#9295A1" />
         </button>
 
-        <div className="center-title">Language</div>
+        <div className="center-title">{t('language')}</div>
       </div>
       <ul className={languageSelectorListStyle}>
         {Object.keys(LOCALE_MAP).map((lang) => (

--- a/apps/web/src/components/Layout/LanguageSelector.tsx
+++ b/apps/web/src/components/Layout/LanguageSelector.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import React, { useState } from 'react';
-import { css } from '_panda/css';
+import { useLocale } from 'next-intl';
+import { css, cx } from '_panda/css';
+import { RadioButtonOff, RadioButtonOn } from '@gitanimals/ui-icon';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Globe } from 'lucide-react';
+import { ChevronLeft, Globe } from 'lucide-react';
 
 import { Link, type Locale, usePathname } from '@/i18n/routing';
 
@@ -12,7 +14,7 @@ const LOCALE_MAP: Record<Locale, string> = {
   ko_KR: '한국어',
 };
 
-const LanguageSelector = () => {
+export const DesktopLanguageSelector = () => {
   const pathname = usePathname();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -34,7 +36,7 @@ const LanguageSelector = () => {
           >
             {Object.keys(LOCALE_MAP).map((lang) => (
               <Link href={pathname} key={lang} locale={lang as Locale} passHref>
-                <motion.button key={lang} onClick={() => setIsOpen(false)} className={optionStyles}>
+                <motion.button key={lang} onClick={() => setIsOpen(false)} className="option">
                   {LOCALE_MAP[lang as Locale]}
                 </motion.button>
               </Link>
@@ -45,8 +47,6 @@ const LanguageSelector = () => {
     </div>
   );
 };
-
-export default LanguageSelector;
 
 const containerStyles = css({
   position: 'relative',
@@ -65,17 +65,90 @@ const dropdownStyles = css({
   minWidth: 'fit-content',
   width: '100%',
   zIndex: 200,
+
+  '& .option': {
+    w: '100%',
+    textAlign: 'left',
+    px: '16px',
+    py: '8px',
+    transition: 'background-color 0.2s',
+    color: '#000',
+    whiteSpace: 'nowrap',
+    _hover: {
+      textDecoration: 'underline',
+    },
+  },
 });
 
-const optionStyles = css({
-  w: '100%',
-  textAlign: 'left',
-  px: '16px',
-  py: '8px',
-  transition: 'background-color 0.2s',
-  color: '#000',
-  whiteSpace: 'nowrap',
-  _hover: {
-    textDecoration: 'underline',
+export function MobileLanguageSelector({ onBack }: { onBack: () => void }) {
+  const pathname = usePathname();
+  const locale = useLocale();
+
+  return (
+    <article className={languageSelectorContainerStyle}>
+      <div className={cx(languageSelectorHeaderStyle)}>
+        <button onClick={onBack}>
+          <ChevronLeft size={24} color="#9295A1" />
+        </button>
+
+        <div className="center-title">Language</div>
+      </div>
+      <ul className={languageSelectorListStyle}>
+        {Object.keys(LOCALE_MAP).map((lang) => (
+          <Link href={pathname} key={lang} locale={lang as Locale}>
+            <li key={lang}>
+              <div className="label">{LOCALE_MAP[lang as Locale]}</div>
+              <div>{locale === lang ? <RadioButtonOn /> : <RadioButtonOff />}</div>
+            </li>
+          </Link>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+const languageSelectorContainerStyle = css({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: '#fff',
+  maxHeight: '100vh',
+  overflowY: 'auto',
+  zIndex: 2002,
+});
+
+const languageSelectorHeaderStyle = css({
+  padding: '0 16px',
+  textStyle: 'glyph18.regular',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  position: 'relative',
+  width: '100%',
+  height: 44,
+
+  '& .center-title': {
+    width: 'fit-content',
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
+  },
+});
+
+const languageSelectorListStyle = css({
+  width: '100%',
+  textStyle: 'glyph16.regular',
+
+  '& li': {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '18px 22px 18px 20px',
+
+    borderBottom: '1px solid',
+    borderColor: 'gray.gray_900',
+    backgroundColor: 'white',
   },
 });

--- a/apps/web/src/components/Layout/MobileGNB.tsx
+++ b/apps/web/src/components/Layout/MobileGNB.tsx
@@ -67,13 +67,13 @@ export const MobileGNB = () => {
                 </AdaptiveLink>
               ))}
               <button onClick={() => setIsLanguageSelectorOpen(true)}>
-                <MenuItem icon={<Globe size={20} color="#9295A1" />} label="Language" />
+                <MenuItem icon={<Globe size={20} color="#9295A1" />} label={t('language')} />
               </button>
               <button>
                 {isAuth ? (
-                  <MenuItem icon={<LogOutIcon size={20} color="#9295A1" />} label="Logout" />
+                  <MenuItem icon={<LogOutIcon size={20} color="#9295A1" />} label={t('logout')} />
                 ) : (
-                  <MenuItem icon={<LogInIcon size={20} color="#9295A1" />} label="Login" />
+                  <MenuItem icon={<LogInIcon size={20} color="#9295A1" />} label={t('login')} />
                 )}
               </button>
             </ul>

--- a/apps/web/src/components/Layout/MobileGNB.tsx
+++ b/apps/web/src/components/Layout/MobileGNB.tsx
@@ -3,26 +3,27 @@ import React, { useState } from 'react';
 import Image from 'next/image';
 import { css, cx } from '_panda/css';
 import { flex } from '_panda/patterns';
-import { GithubIcon } from '@gitanimals/ui-icon';
+import { GithubIcon, RadioButtonOff, RadioButtonOn } from '@gitanimals/ui-icon';
 import type { Transition, Variants } from 'framer-motion';
 import { AnimatePresence, motion } from 'framer-motion';
-import { ChevronRight, Globe, LogInIcon, LogOutIcon, Menu, ShoppingCart } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Globe, LogInIcon, LogOutIcon, Menu, ShoppingCart } from 'lucide-react';
 
 import { GIT_ANIMALS_MAIN_URL } from '@/constants/outlink';
-import { Link } from '@/i18n/routing';
+import type { Locale } from '@/i18n/routing';
+import { Link, usePathname } from '@/i18n/routing';
 import { useClientSession } from '@/utils/clientAuth';
 
 export const MobileGNB = () => {
   const session = useClientSession();
 
   const [isOpen, setIsOpen] = useState(false);
-
+  const [isLanguageSelectorOpen, setIsLanguageSelectorOpen] = useState(true);
   const toggleMenu = () => {
     setIsOpen(!isOpen);
   };
 
   return (
-    <div>
+    <>
       <header className={cx(headerBaseStyle, mobileHeaderStyle)}>
         <div className={mobileHeaderContentStyle}>
           <button onClick={toggleMenu}>
@@ -52,7 +53,7 @@ export const MobileGNB = () => {
               <a href={GIT_ANIMALS_MAIN_URL} target="_blank">
                 <MenuItem icon={<GithubIcon width={22} height={22} color="#6e717a" />} label="Github" />
               </a>
-              <button>
+              <button onClick={() => setIsLanguageSelectorOpen(true)}>
                 <MenuItem icon={<Globe size={20} color="#9295A1" />} label="Language" />
               </button>
               <button>
@@ -66,7 +67,8 @@ export const MobileGNB = () => {
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
+      {isLanguageSelectorOpen && <LanguageSelector onBack={() => setIsLanguageSelectorOpen(false)} />}
+    </>
   );
 };
 
@@ -81,6 +83,72 @@ function MenuItem({ icon, label, isArrow = true }: { icon: React.ReactNode; labe
     </motion.li>
   );
 }
+
+// TODO : LanguageSelector 공통화
+const LOCALE_MAP: Record<Locale, string> = {
+  en_US: 'English',
+  ko_KR: '한국어',
+};
+
+function LanguageSelector({ onBack }: { onBack: () => void }) {
+  const pathname = usePathname();
+
+  return (
+    <article className={languageSelectorContainerStyle}>
+      <div className={cx(mobileHeaderContentStyle, languageSelectorHeaderStyle)}>
+        <button onClick={onBack}>
+          <ChevronLeft size={24} color="#9295A1" />
+        </button>
+
+        <div className={mobileLogoStyle}>Language</div>
+      </div>
+      <ul className={languageSelectorListStyle}>
+        {Object.keys(LOCALE_MAP).map((lang) => (
+          <Link href={pathname} key={lang} locale={lang as Locale} passHref>
+            <li key={lang}>
+              <div className="label">{LOCALE_MAP[lang as Locale]}</div>
+              <div>{true ? <RadioButtonOn /> : <RadioButtonOff />}</div>
+            </li>
+          </Link>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+const languageSelectorListStyle = css({
+  width: '100%',
+
+  textStyle: 'glyph16.regular',
+
+  '& li': {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '18px 22px 18px 20px',
+
+    borderBottom: '1px solid',
+    borderColor: 'gray.gray_900',
+    backgroundColor: 'white',
+  },
+});
+
+const languageSelectorContainerStyle = css({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: '#fff',
+  maxHeight: '100vh',
+  overflowY: 'auto',
+  zIndex: 101,
+});
+
+const languageSelectorHeaderStyle = css({
+  padding: '0 16px',
+  textStyle: 'glyph18.regular',
+});
 
 const headerBaseStyle = flex({
   justifyContent: 'space-between',
@@ -108,11 +176,13 @@ const mobileHeaderContentStyle = css({
   alignItems: 'center',
   justifyContent: 'space-between',
   position: 'relative',
-  width: 'calc(100vw - 40px)',
+  width: '100%',
+  height: 44,
 });
 
 const mobileLogoStyle = css({
-  width: '80px',
+  // width: '80px',
+  width: 'fit-content',
   position: 'absolute',
   left: '50%',
   transform: 'translateX(-50%)',

--- a/apps/web/src/components/Layout/MobileGNB.tsx
+++ b/apps/web/src/components/Layout/MobileGNB.tsx
@@ -10,6 +10,7 @@ import type { Transition, Variants } from 'framer-motion';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronLeft, ChevronRight, Globe, LogInIcon, LogOutIcon, Menu } from 'lucide-react';
 
+import { AdaptiveLink } from '@/components/AdaptiveLink';
 import type { Locale } from '@/i18n/routing';
 import { Link, usePathname } from '@/i18n/routing';
 import { useClientSession } from '@/utils/clientAuth';
@@ -84,13 +85,6 @@ export const MobileGNB = () => {
   );
 };
 
-const AdaptiveLink: React.FC<{ href: string; children: React.ReactNode }> = ({ href, children }) => {
-  if (isExternalLink(href)) {
-    return <a href={href}>{children}</a>;
-  }
-  return <Link href={href}>{children}</Link>;
-};
-
 function MenuItem({ icon, label, isArrow = true }: { icon: ReactNode; label: string; isArrow?: boolean }) {
   return (
     <motion.li className={menuItemStyle}>
@@ -161,7 +155,7 @@ const languageSelectorContainerStyle = css({
   backgroundColor: '#fff',
   maxHeight: '100vh',
   overflowY: 'auto',
-  zIndex: 101,
+  zIndex: 2002,
 });
 
 const languageSelectorHeaderStyle = css({
@@ -172,7 +166,7 @@ const languageSelectorHeaderStyle = css({
 const headerBaseStyle = flex({
   justifyContent: 'space-between',
   alignItems: 'center',
-  zIndex: 100,
+  zIndex: 2000,
   position: 'fixed',
   padding: '0 20px',
   top: 0,
@@ -216,7 +210,7 @@ const mobileMenuStyle = css({
   maxHeight: 'calc(100vh - 60px)',
   overflowY: 'auto',
   boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-  zIndex: 99,
+  zIndex: 1999,
 
   _mobile: {
     display: 'flex',

--- a/apps/web/src/components/Layout/MobileGNB.tsx
+++ b/apps/web/src/components/Layout/MobileGNB.tsx
@@ -1,20 +1,20 @@
 'use client';
+
 import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { css, cx } from '_panda/css';
 import { flex } from '_panda/patterns';
-import { RadioButtonOff, RadioButtonOn } from '@gitanimals/ui-icon';
 import type { Transition, Variants } from 'framer-motion';
 import { AnimatePresence, motion } from 'framer-motion';
-import { ChevronLeft, ChevronRight, Globe, LogInIcon, LogOutIcon, Menu } from 'lucide-react';
+import { ChevronRight, Globe, LogInIcon, LogOutIcon, Menu } from 'lucide-react';
 
 import { AdaptiveLink } from '@/components/AdaptiveLink';
-import type { Locale } from '@/i18n/routing';
-import { Link, usePathname } from '@/i18n/routing';
+import { Link } from '@/i18n/routing';
 import { useClientSession } from '@/utils/clientAuth';
 
+import { MobileLanguageSelector } from './LanguageSelector';
 import { LOGIN_NAV_MENU_LIST, NON_LOGIN_NAV_MENU_LIST } from './menu.constants';
 
 export const MobileGNB = () => {
@@ -80,7 +80,7 @@ export const MobileGNB = () => {
           </motion.div>
         )}
       </AnimatePresence>
-      {isLanguageSelectorOpen && <LanguageSelector onBack={() => setIsLanguageSelectorOpen(false)} />}
+      {isLanguageSelectorOpen && <MobileLanguageSelector onBack={() => setIsLanguageSelectorOpen(false)} />}
     </>
   );
 };
@@ -97,70 +97,20 @@ function MenuItem({ icon, label, isArrow = true }: { icon: ReactNode; label: str
   );
 }
 
-// TODO : LanguageSelector 공통화
-const LOCALE_MAP: Record<Locale, string> = {
-  en_US: 'English',
-  ko_KR: '한국어',
-};
-
-function LanguageSelector({ onBack }: { onBack: () => void }) {
-  const pathname = usePathname();
-  const locale = useLocale();
-  return (
-    <article className={languageSelectorContainerStyle}>
-      <div className={cx(mobileHeaderContentStyle, languageSelectorHeaderStyle)}>
-        <button onClick={onBack}>
-          <ChevronLeft size={24} color="#9295A1" />
-        </button>
-
-        <div className={mobileLogoStyle}>Language</div>
-      </div>
-      <ul className={languageSelectorListStyle}>
-        {Object.keys(LOCALE_MAP).map((lang) => (
-          <Link href={pathname} key={lang} locale={lang as Locale}>
-            <li key={lang}>
-              <div className="label">{LOCALE_MAP[lang as Locale]}</div>
-              <div>{locale === lang ? <RadioButtonOn /> : <RadioButtonOff />}</div>
-            </li>
-          </Link>
-        ))}
-      </ul>
-    </article>
-  );
-}
-
-const languageSelectorListStyle = css({
+const mobileHeaderContentStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  position: 'relative',
   width: '100%',
-
-  textStyle: 'glyph16.regular',
-
-  '& li': {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: '18px 22px 18px 20px',
-
-    borderBottom: '1px solid',
-    borderColor: 'gray.gray_900',
-    backgroundColor: 'white',
-  },
+  height: 44,
 });
 
-const languageSelectorContainerStyle = css({
-  position: 'fixed',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  backgroundColor: '#fff',
-  maxHeight: '100vh',
-  overflowY: 'auto',
-  zIndex: 2002,
-});
-
-const languageSelectorHeaderStyle = css({
-  padding: '0 16px',
-  textStyle: 'glyph18.regular',
+const mobileLogoStyle = css({
+  width: 'fit-content',
+  position: 'absolute',
+  left: '50%',
+  transform: 'translateX(-50%)',
 });
 
 const headerBaseStyle = flex({
@@ -182,23 +132,6 @@ const mobileHeaderStyle = css({
   _mobile: {
     display: 'flex',
   },
-});
-
-const mobileHeaderContentStyle = css({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  position: 'relative',
-  width: '100%',
-  height: 44,
-});
-
-const mobileLogoStyle = css({
-  // width: '80px',
-  width: 'fit-content',
-  position: 'absolute',
-  left: '50%',
-  transform: 'translateX(-50%)',
 });
 
 const mobileMenuStyle = css({

--- a/apps/web/src/components/Layout/MobileGNB.tsx
+++ b/apps/web/src/components/Layout/MobileGNB.tsx
@@ -26,6 +26,8 @@ export const MobileGNB = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [isLanguageSelectorOpen, setIsLanguageSelectorOpen] = useState(false);
 
+  const menuList = isAuth ? [...LOGIN_NAV_MENU_LIST, ...NON_LOGIN_NAV_MENU_LIST] : NON_LOGIN_NAV_MENU_LIST;
+
   const toggleMenu = () => {
     setIsOpen(!isOpen);
   };
@@ -63,13 +65,7 @@ export const MobileGNB = () => {
             className={mobileMenuStyle}
           >
             <ul className="menu-list">
-              {isAuth &&
-                LOGIN_NAV_MENU_LIST.map((menu) => (
-                  <AdaptiveLink href={menu.href} key={menu.label}>
-                    <MenuItem {...menu} label={t(menu.label)} />
-                  </AdaptiveLink>
-                ))}
-              {NON_LOGIN_NAV_MENU_LIST.map((menu) => (
+              {menuList.map((menu) => (
                 <AdaptiveLink href={menu.href} key={menu.label}>
                   <MenuItem {...menu} label={t(menu.label)} />
                 </AdaptiveLink>

--- a/apps/web/src/components/Layout/MobileGNB.tsx
+++ b/apps/web/src/components/Layout/MobileGNB.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
-import { css, cx } from '_panda/css';
+import { css } from '_panda/css';
 import { flex } from '_panda/patterns';
 import type { Transition, Variants } from 'framer-motion';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -32,13 +32,13 @@ export const MobileGNB = () => {
 
   return (
     <>
-      <header className={cx(headerBaseStyle, mobileHeaderStyle)}>
+      <header className={mobileHeaderStyle}>
         <div className={mobileHeaderContentStyle}>
           <button onClick={toggleMenu}>
             <Menu size={24} color="black" />
           </button>
 
-          <Link href="/" className={mobileLogoStyle}>
+          <Link href="/" className="center-title">
             <Image src="/main/gnb_right_logo.svg" alt="gitanimals-logo" width={80} height={22} />
           </Link>
         </div>
@@ -54,7 +54,7 @@ export const MobileGNB = () => {
             transition={menuTransition}
             className={mobileMenuStyle}
           >
-            <ul className={mobileMenuListStyle}>
+            <ul className="menu-list">
               {isAuth &&
                 LOGIN_NAV_MENU_LIST.map((menu) => (
                   <AdaptiveLink href={menu.href} key={menu.label}>
@@ -104,16 +104,11 @@ const mobileHeaderContentStyle = css({
   position: 'relative',
   width: '100%',
   height: 44,
+  '& .center-title': { width: 'fit-content', position: 'absolute', left: '50%', transform: 'translateX(-50%)' },
 });
 
-const mobileLogoStyle = css({
-  width: 'fit-content',
-  position: 'absolute',
-  left: '50%',
-  transform: 'translateX(-50%)',
-});
-
-const headerBaseStyle = flex({
+const mobileHeaderStyle = css({
+  // common
   justifyContent: 'space-between',
   alignItems: 'center',
   zIndex: 2000,
@@ -121,13 +116,10 @@ const headerBaseStyle = flex({
   padding: '0 20px',
   top: 0,
   height: 60,
-  width: '100%',
   backgroundColor: 'white',
-});
 
-const mobileHeaderStyle = css({
+  // mobile
   width: '100vw',
-
   display: 'none',
   _mobile: {
     display: 'flex',
@@ -148,12 +140,12 @@ const mobileMenuStyle = css({
   _mobile: {
     display: 'flex',
   },
-});
 
-const mobileMenuListStyle = css({
-  width: '100%',
-  '& >  *': {
+  '& .menu-list': {
     width: '100%',
+    '& >  *': {
+      width: '100%',
+    },
   },
 });
 

--- a/apps/web/src/components/Layout/MobileGNB.tsx
+++ b/apps/web/src/components/Layout/MobileGNB.tsx
@@ -29,9 +29,9 @@ export const MobileGNB = () => {
             <Menu size={24} color="black" />
           </button>
 
-          <div className={mobileLogoStyle}>
+          <Link href="/" className={mobileLogoStyle}>
             <Image src="/main/gnb_right_logo.svg" alt="gitanimals-logo" width={80} height={22} />
-          </div>
+          </Link>
         </div>
       </header>
 
@@ -135,6 +135,7 @@ const mobileMenuStyle = css({
 });
 
 const mobileMenuListStyle = css({
+  width: '100%',
   '& >  *': {
     width: '100%',
   },

--- a/apps/web/src/components/Layout/MobileGNB.tsx
+++ b/apps/web/src/components/Layout/MobileGNB.tsx
@@ -20,7 +20,7 @@ import { LOGIN_NAV_MENU_LIST, NON_LOGIN_NAV_MENU_LIST } from './menu.constants';
 export const MobileGNB = () => {
   const t = useTranslations('Layout');
 
-  const { status } = useClientSession();
+  const { status, data } = useClientSession();
   const isAuth = status === 'authenticated';
 
   const [isOpen, setIsOpen] = useState(false);
@@ -41,6 +41,14 @@ export const MobileGNB = () => {
           <Link href="/" className="center-title">
             <Image src="/main/gnb_right_logo.svg" alt="gitanimals-logo" width={80} height={22} />
           </Link>
+
+          {isAuth && (
+            <Link href="/mypage">
+              <div className="profile-image">
+                <Image src={data.user.image} alt="profile" width={28} height={28} />
+              </div>
+            </Link>
+          )}
         </div>
       </header>
 
@@ -105,6 +113,12 @@ const mobileHeaderContentStyle = css({
   width: '100%',
   height: 44,
   '& .center-title': { width: 'fit-content', position: 'absolute', left: '50%', transform: 'translateX(-50%)' },
+  '& .profile-image': {
+    width: 28,
+    height: 28,
+    borderRadius: '50%',
+    overflow: 'hidden',
+  },
 });
 
 const mobileHeaderStyle = css({

--- a/apps/web/src/components/Layout/menu.constants.tsx
+++ b/apps/web/src/components/Layout/menu.constants.tsx
@@ -1,15 +1,21 @@
+import type { ReactNode } from 'react';
+import { GithubIcon } from '@gitanimals/ui-icon';
+import { ShoppingCartIcon } from 'lucide-react';
+
 import { GIT_ANIMALS_MAIN_URL } from '@/constants/outlink';
 
 export interface NavMenu {
   label: string;
   href: string;
   isExternal?: boolean;
+  icon: ReactNode;
 }
 
 export const LOGIN_NAV_MENU_LIST: NavMenu[] = [
   {
-    label: 'auction',
+    label: 'shop',
     href: '/shop',
+    icon: <ShoppingCartIcon size={20} color="#9295A1" />,
   },
 ] as const;
 
@@ -18,5 +24,6 @@ export const NON_LOGIN_NAV_MENU_LIST: NavMenu[] = [
     label: 'github',
     href: GIT_ANIMALS_MAIN_URL,
     isExternal: true,
+    icon: <GithubIcon width={22} height={22} color="#6e717a" />,
   },
 ] as const;

--- a/packages/ui/icon/src/icons/RadioButton.tsx
+++ b/packages/ui/icon/src/icons/RadioButton.tsx
@@ -1,0 +1,32 @@
+import { FC, ComponentProps } from 'react';
+import Svg from '../Svg';
+
+export const RadioButtonOn: FC<ComponentProps<typeof Svg>> = ({ color = '#00894D', ...rest }) => {
+  return (
+    <Svg width={24} height={24} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...rest}>
+      <path
+        d="M12 16.998C14.7614 16.998 17 14.7595 17 11.998C17 9.23662 14.7614 6.99805 12 6.99805C9.23858 6.99805 7 9.23662 7 11.998C7 14.7595 9.23858 16.998 12 16.998Z"
+        fill={color}
+      />
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12ZM19.5 12C19.5 16.1421 16.1421 19.5 12 19.5C7.85786 19.5 4.5 16.1421 4.5 12C4.5 7.85786 7.85786 4.5 12 4.5C16.1421 4.5 19.5 7.85786 19.5 12Z"
+        fill={color}
+      />
+    </Svg>
+  );
+};
+
+export const RadioButtonOff: FC<ComponentProps<typeof Svg>> = ({ color = '#D8D9DD', ...rest }) => {
+  return (
+    <Svg width={24} height={24} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...rest}>
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M12 19.5C16.1421 19.5 19.5 16.1421 19.5 12C19.5 7.85788 16.1421 4.50003 12 4.50003C7.85788 4.50003 4.50003 7.85788 4.50003 12C4.50003 16.1421 7.85788 19.5 12 19.5ZM12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21Z"
+        fill={color}
+      />
+    </Svg>
+  );
+};

--- a/packages/ui/icon/src/index.ts
+++ b/packages/ui/icon/src/index.ts
@@ -4,3 +4,4 @@ export { BehanceIcon } from './icons/BehanceIcon';
 export { XIcon } from './icons/XIcon';
 export { SearchIcon } from './icons/SearchIcon';
 export { CloseIcon } from './icons/CloseIcon';
+export { RadioButtonOn, RadioButtonOff } from './icons/RadioButton';

--- a/packages/util/common/src/index.ts
+++ b/packages/util/common/src/index.ts
@@ -1,1 +1,2 @@
-export {};
+export * from './url';
+export { isExternalLink } from './url';

--- a/packages/util/common/src/index.ts
+++ b/packages/util/common/src/index.ts
@@ -1,2 +1,1 @@
 export * from './url';
-export { isExternalLink } from './url';

--- a/packages/util/common/src/url.ts
+++ b/packages/util/common/src/url.ts
@@ -1,0 +1,3 @@
+export function isExternalLink(url: string): boolean {
+  return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('//');
+}


### PR DESCRIPTION
# 💡 기능
모바일 GNB를 추가하였습니다. 
- 로그인 유무에 따라 보여주는 menu list가 달라집니다. 
- Desktop에서 사용되는 nav menu를 동일하게 사용하였어요. (icon 추가)
- link url에 따라 a태그 or Link 태그를 렌더링하는 `AdaptiveLink` 컴포넌트를 생성하였습니다. a tag(외부 경로)는 기본적으로 새탭으로 열립니다. 

# 🔎 기타
- 로그인, 로그아웃 로직은 리팩토링을 해야할것 같아 다른 PR에서 이어서 작업하였습니다. 

<img width="374" alt="image" src="https://github.com/user-attachments/assets/9420f72d-ac5e-4484-9327-d7e22fd1011e">
