### PR TITLE
fix: PetGotcha에서 첫번째 카드 아이템을 선택해도 뒤집어지지 않는 오류

### DIFF
--- a/apps/web/src/app/[locale]/shop/PetGotcha/CardFlipGame.tsx
+++ b/apps/web/src/app/[locale]/shop/PetGotcha/CardFlipGame.tsx
@@ -23,7 +23,7 @@ const CardFlipGame = ({ onGetPersona, getPersona }: CardFlipGameProps) => {
   const [selectedCard, setSelectedCard] = useState<number | null>(null);
 
   const isShaking = selectedCard !== null && getPersona === null; // 카드가 선택되었지만 페르소나가 선택되지 않았을 때
-  const isFlipped = getPersona && selectedCard; // 뽑힌 페르소나가 정해졌을 때
+  const isFlipped = getPersona && selectedCard !== null; // 뽑힌 페르소나가 정해졌을 때
 
   const handleCardClick = (index: number) => {
     if (selectedCard === null) {


### PR DESCRIPTION
# 🚨버그
- `Shop` page에서 PetGotcha를 진행할 때, 첫번째 카드를 선택해도 카드가 뒤집어지지 않는 오류가 있습니다.

https://github.com/user-attachments/assets/f3e7de3e-357f-4685-b127-7778d8e0f52a

```tsx
// 26:apps/web/src/app/[locale]/shop/PetGotcha/CardFlipGame.tsx
const isFlipped = getPersona && selectedCard; // 뽑힌 페르소나가 정해졌을 때
```

해당 줄에서 첫번째 카드의 경우 `selectedCard` 0일 때, falsy 로 평가되어 발생하는 오류를 확인했습니다.
`selectedCard !== null` 으로 변경하여 `selectedCard`가 null이 아닐때만 존재하도록 변경하면 어떨까 싶습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 카드 플립 게임의 로직을 개선하여 선택된 카드가 `null`인지 확인하는 조건을 명확히 하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->