### PR TITLE
refactor: preview, select persona등 로직 분리

### DIFF
--- a/apps/web/messages/en_US.json
+++ b/apps/web/messages/en_US.json
@@ -84,7 +84,8 @@
     "pet-list": "Pet list",
     "sell-to-other": "Tip. If you want to sell your pet to other users, please use the auction.",
     "my-pet": "My pet",
-    "github-custom": "Github Custom"
+    "github-custom": "Github Custom",
+    "invalid-size-error": "Invalid size"
   },
   "Event": {
     "Halloween": {

--- a/apps/web/messages/ko_KR.json
+++ b/apps/web/messages/ko_KR.json
@@ -86,7 +86,8 @@
     "pet-list": "펫 목록",
     "sell-to-other": "Tip. 다른 사용자에게 펫을 팔고싶다면, 경매장을 이용해주세요.",
     "my-pet": "내 펫",
-    "github-custom": "Github Custom"
+    "github-custom": "Github Custom",
+    "invalid-size-error": "유효하지 않은 사이즈"
   },
   "Event": {
     "Halloween": {

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/FarmPersonaSelect.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/FarmPersonaSelect.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { css } from '_panda/css';
+import type { Persona } from '@gitanimals/api';
+import { userQueries } from '@gitanimals/react-query';
+import { Button } from '@gitanimals/ui-panda';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useChangePersonaVisible } from '@/apis/persona/useChangePersonaVisible';
+
+import { SelectPersonaList } from '../PersonaList';
+
+export function FarmPersonaSelect({
+  onChangeStatus,
+}: {
+  onChangeStatus: (status: 'loading' | 'success' | 'error') => void;
+}) {
+  const queryClient = useQueryClient();
+  const t = useTranslations('Mypage');
+
+  const [selectPersona, setSelectPersona] = useState<string[]>([]);
+  const [loadingPersona, setLoadingPersona] = useState<string[]>([]);
+  const [isExtend, setIsExtend] = useState(false);
+
+  const { mutate } = useChangePersonaVisible({
+    onMutate: () => {
+      onChangeStatus('loading');
+    },
+    onSuccess: (res) => {
+      if (res.visible) {
+        setSelectPersona((prev) => Array.from(new Set([...prev, res.id])));
+      } else {
+        setSelectPersona((prev) => prev.filter((id) => id !== res.id));
+      }
+    },
+    onError: () => {
+      onChangeStatus('error');
+    },
+    onSettled: async (res) => {
+      await queryClient.invalidateQueries({ queryKey: userQueries.allPersonasKey() });
+      onChangeStatus('success');
+      setLoadingPersona((prev) => prev.filter((id) => id !== res?.id));
+    },
+  });
+
+  const onSelectPersona = (persona: Persona) => {
+    setLoadingPersona((prev) => [...prev, persona.id]);
+
+    const isVisible = selectPersona.includes(persona.id);
+
+    if (isVisible) {
+      mutate({ personaId: persona.id, visible: false });
+    } else {
+      mutate({ personaId: persona.id, visible: true });
+    }
+  };
+
+  const initSelectPersonas = (list: Persona[]) => {
+    const visiblePersonaIds = list.filter((persona) => persona.visible).map((persona) => persona.id);
+    setSelectPersona(visiblePersonaIds);
+  };
+
+  return (
+    <>
+      <section className={selectPetContainerStyle}>
+        <h2 className="heading">{t('change-pet')}</h2>
+        <Button className="extend-button" onClick={() => setIsExtend((prev) => !prev)}>
+          {isExtend ? t('shrink-button') : t('extend-button')}
+        </Button>
+      </section>
+      <section className={isExtend ? flexGrowSectionStyle : ''}>
+        <SelectPersonaList
+          loadingPersona={loadingPersona}
+          selectPersona={selectPersona}
+          onSelectPersona={onSelectPersona}
+          initSelectPersonas={initSelectPersonas}
+          isExtend={isExtend}
+        />
+      </section>
+    </>
+  );
+}
+
+const flexGrowSectionStyle = css({
+  flex: '1',
+  minHeight: '0',
+  overflow: 'auto',
+  display: 'flex',
+  flexWrap: 'wrap',
+});
+
+const selectPetContainerStyle = css({
+  position: 'relative',
+  '& .heading': {
+    textStyle: 'glyph18.bold',
+    color: 'white',
+    marginBottom: '16px',
+  },
+  '& .extend-button': {
+    position: 'absolute',
+    top: '-16px',
+    right: 0,
+  },
+});

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/FarmType.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/FarmType.tsx
@@ -5,58 +5,21 @@
 import React, { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { css } from '_panda/css';
-import type { Persona } from '@gitanimals/api';
-import { userQueries } from '@gitanimals/react-query';
 import { Button } from '@gitanimals/ui-panda';
-import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { useChangePersonaVisible } from '@/apis/persona/useChangePersonaVisible';
 import { getGitanimalsFarmString, GitanimalsFarm } from '@/components/Gitanimals';
 import { useClientUser } from '@/utils/clientAuth';
 import { copyClipBoard } from '@/utils/copy';
 
-import { SelectPersonaList } from '../PersonaList';
+import { FarmPersonaSelect } from './FarmPersonaSelect';
 
 export function FarmType() {
-  const queryClient = useQueryClient();
   const t = useTranslations('Mypage');
 
   const { name } = useClientUser();
-  const [selectPersona, setSelectPersona] = useState<string[]>([]);
-  const [loadingPersona, setLoadingPersona] = useState<string[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [isExtend, setIsExtend] = useState(false);
 
-  const { mutate } = useChangePersonaVisible({
-    onMutate: () => {
-      setLoading(true);
-    },
-    onSuccess: (res) => {
-      if (res.visible) {
-        setSelectPersona((prev) => Array.from(new Set([...prev, res.id])));
-      } else {
-        setSelectPersona((prev) => prev.filter((id) => id !== res.id));
-      }
-    },
-    onSettled: async (res) => {
-      await queryClient.invalidateQueries({ queryKey: userQueries.allPersonasKey() });
-      setLoading(false);
-      setLoadingPersona((prev) => prev.filter((id) => id !== res?.id));
-    },
-  });
-
-  const onSelectPersona = (persona: Persona) => {
-    setLoadingPersona((prev) => [...prev, persona.id]);
-
-    const isVisible = selectPersona.includes(persona.id);
-
-    if (isVisible) {
-      mutate({ personaId: persona.id, visible: false });
-    } else {
-      mutate({ personaId: persona.id, visible: true });
-    }
-  };
+  const [selectPersonaStatus, setSelectPersonaStatus] = useState<'loading' | 'success' | 'error'>('loading');
 
   const onLinkCopy = async () => {
     try {
@@ -70,33 +33,12 @@ export function FarmType() {
     } catch (error) {}
   };
 
-  const initSelectPersonas = (list: Persona[]) => {
-    const visiblePersonaIds = list.filter((persona) => persona.visible).map((persona) => persona.id);
-    setSelectPersona(visiblePersonaIds);
-  };
-
   return (
     <div className={farmSectionStyle}>
-      <section className={selectPetContainerStyle}>
-        <h2 className="heading">{t('change-pet')}</h2>
-        <Button className="extend-button" onClick={() => setIsExtend((prev) => !prev)}>
-          {isExtend ? t('shrink-button') : t('extend-button')}
-        </Button>
-      </section>
-      <section className={isExtend ? flexGrowSectionStyle : ''}>
-        <SelectPersonaList
-          name={name}
-          loadingPersona={loadingPersona}
-          selectPersona={selectPersona}
-          onSelectPersona={onSelectPersona}
-          initSelectPersonas={initSelectPersonas}
-          isExtend={isExtend}
-        />
-      </section>
-
+      <FarmPersonaSelect onChangeStatus={setSelectPersonaStatus} />
       <div>
         <div className={farmStyle}>
-          <GitanimalsFarm imageKey={`${selectPersona.length}/${loading ? 'loading' : ''}`} sizes={[600, 300]} />
+          <GitanimalsFarm imageKey={selectPersonaStatus} sizes={[600, 300]} />
         </div>
         <Button onClick={onLinkCopy} mt={16} size="m">
           {t('copy-link-title')}
@@ -105,14 +47,6 @@ export function FarmType() {
     </div>
   );
 }
-
-const flexGrowSectionStyle = css({
-  flex: '1',
-  minHeight: '0',
-  overflow: 'auto',
-  display: 'flex',
-  flexWrap: 'wrap',
-});
 
 const farmSectionStyle = css({
   display: 'flex',
@@ -131,17 +65,3 @@ const farmSectionStyle = css({
 });
 
 const farmStyle = css({ borderRadius: '12px', overflow: 'hidden', width: 'fit-content', mt: 24 });
-
-const selectPetContainerStyle = css({
-  position: 'relative',
-  '& .heading': {
-    textStyle: 'glyph18.bold',
-    color: 'white',
-    marginBottom: '16px',
-  },
-  '& .extend-button': {
-    position: 'absolute',
-    top: '-16px',
-    right: 0,
-  },
-});

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/LinePersonaSelect.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/LinePersonaSelect.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { css } from '_panda/css';
+import { Button } from '@gitanimals/ui-panda';
+
+import { SelectPersonaList } from '../PersonaList';
+
+export const LinePersonaSelect = ({
+  selectPersona,
+  onChangePersona,
+}: {
+  selectPersona: string | null;
+  onChangePersona: (personaId: string) => void;
+}) => {
+  const t = useTranslations('Mypage');
+
+  const [isExtend, setIsExtend] = useState(false);
+
+  return (
+    <>
+      <section className={selectPetContainerStyle}>
+        <h2 className="heading">{t('change-pet')}</h2>
+        <Button className="extend-button" onClick={() => setIsExtend((prev) => !prev)}>
+          {isExtend ? t('shrink-button') : t('extend-button')}
+        </Button>
+      </section>
+      <section className={isExtend ? flexGrowSectionStyle : ''}>
+        <SelectPersonaList
+          selectPersona={selectPersona ? [selectPersona] : []}
+          onSelectPersona={(persona) => onChangePersona(persona.id)}
+          isExtend={isExtend}
+        />
+      </section>
+    </>
+  );
+};
+
+const flexGrowSectionStyle = css({
+  flex: '1',
+  minHeight: '0',
+  overflow: 'auto',
+  display: 'flex',
+  flexWrap: 'wrap',
+});
+
+const selectPetContainerStyle = css({
+  position: 'relative',
+  '& .heading': {
+    textStyle: 'glyph18.bold',
+    color: 'white',
+    marginBottom: '16px',
+  },
+  '& .extend-button': {
+    position: 'absolute',
+    top: '-16px',
+    right: 0,
+  },
+});

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/LinePersonaSelect.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/LinePersonaSelect.tsx
@@ -7,16 +7,15 @@ import { Button } from '@gitanimals/ui-panda';
 
 import { SelectPersonaList } from '../PersonaList';
 
-export const LinePersonaSelect = ({
-  selectPersona,
-  onChangePersona,
-}: {
+interface Props {
   selectPersona: string | null;
   onChangePersona: (personaId: string) => void;
-}) => {
+}
+
+export const LinePersonaSelect = ({ selectPersona, onChangePersona }: Props) => {
   const t = useTranslations('Mypage');
 
-  const [isExtend, setIsExtend] = useState(false);
+  const [isExtend, setIsExtend] = useState<boolean>(false);
 
   return (
     <>
@@ -50,7 +49,7 @@ const selectPetContainerStyle = css({
   '& .heading': {
     textStyle: 'glyph18.bold',
     color: 'white',
-    marginBottom: '16px',
+    marginBottom: 16,
   },
   '& .extend-button': {
     position: 'absolute',

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/LinePreview.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/LinePreview.tsx
@@ -76,8 +76,18 @@ function SizeInputList({ onApply }: { onApply: (width: number, height: number) =
       <h2 className="heading">{t('customize-size')}</h2>
       <div className={flex({ gap: 12 })}>
         <SizeInput value={width} onChange={(e) => setWidth(parseInt(e.target.value))} name="width" />
-        <SizeInput value={height} onChange={(e) => setHeight(parseInt(e.target.value))} name="height" />
-        <Button onClick={() => onApply(width, height)}>{t('apply-button')}</Button>
+        <SizeInput value={height} onChange={(e) => setHeight(parseInt(e.target.value))} name="height" />+{' '}
+        <Button
+          onClick={() => {
+            if (width <= 0 || height <= 0) {
+              toast.error(t('invalid-size-error'));
+              return;
+            }
+            onApply(width, height);
+          }}
+        >
+          {t('apply-button')}
+        </Button>
       </div>
     </div>
   );
@@ -103,6 +113,11 @@ function SizeInput(props: { value: number; onChange: (e: React.ChangeEvent<HTMLI
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value);
+
+    if (isNaN(value)) {
+      toast.error(t('invalid-size-error'));
+      return;
+    }
 
     if (value > 1000) {
       toast.error(t('line-set-error'));

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/LinePreview.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/LinePreview.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { css } from '_panda/css';
+import { flex } from '_panda/patterns';
+import { Button, TextField } from '@gitanimals/ui-panda';
+import { toast } from 'sonner';
+
+import { getGitanimalsLineString, GitanimalsLine } from '@/components/Gitanimals';
+import { useClientUser } from '@/utils/clientAuth';
+import { copyClipBoard } from '@/utils/copy';
+
+const DEFAULT_SIZE = { width: 600, height: 120 };
+
+export function LinePreview({ selectPersona }: { selectPersona: string | null }) {
+  const t = useTranslations('Mypage');
+
+  const { name } = useClientUser();
+  const [sizes, setSizes] = useState<{ width: number; height: number }>(DEFAULT_SIZE);
+
+  const onLinkCopy = async () => {
+    try {
+      await copyClipBoard(
+        getGitanimalsLineString({
+          username: name,
+          petId: selectPersona ?? undefined,
+          sizes: [sizes.width, sizes.height],
+        }),
+      );
+
+      toast.success('복사 성공!', { duration: 2000 });
+    } catch (error) {}
+  };
+
+  return (
+    <>
+      {/* TODO: 임시로 모바일에선 input 안보이게 처리 */}
+      <SizeInputList onApply={(width, height) => setSizes({ width, height })} />
+      <section>
+        <div className={lineContainerStyle} style={{ width: sizes.width, height: sizes.height }}>
+          <GitanimalsLine sizes={[sizes.width, sizes.height]} petId={selectPersona} />
+        </div>
+        <Button onClick={onLinkCopy} mt={16} size="m">
+          {t('copy-link-title')}
+        </Button>
+      </section>
+    </>
+  );
+}
+
+const lineContainerStyle = css({
+  width: '100%',
+  background: 'white',
+  height: '100%',
+  transition: 'all 0.3s',
+  maxWidth: '1000px',
+  borderRadius: '12px',
+
+  '& img': {
+    maxWidth: '100%',
+  },
+  _mobile: {
+    maxWidth: '100%',
+  },
+});
+
+function SizeInputList({ onApply }: { onApply: (width: number, height: number) => void }) {
+  const t = useTranslations('Mypage');
+
+  const [width, setWidth] = useState(DEFAULT_SIZE.width);
+  const [height, setHeight] = useState(DEFAULT_SIZE.height);
+
+  return (
+    <div className={sizeInputStyle}>
+      <h2 className="heading">{t('customize-size')}</h2>
+      <div className={flex({ gap: 12 })}>
+        <SizeInput value={width} onChange={(e) => setWidth(parseInt(e.target.value))} name="width" />
+        <SizeInput value={height} onChange={(e) => setHeight(parseInt(e.target.value))} name="height" />
+        <Button onClick={() => onApply(width, height)}>{t('apply-button')}</Button>
+      </div>
+    </div>
+  );
+}
+
+const sizeInputStyle = css({
+  position: 'relative',
+  mt: 24,
+
+  '& .heading': {
+    textStyle: 'glyph18.bold',
+    color: 'white',
+    marginBottom: '16px',
+  },
+
+  _mobile: {
+    display: 'none',
+  },
+});
+
+function SizeInput(props: { value: number; onChange: (e: React.ChangeEvent<HTMLInputElement>) => void; name: string }) {
+  const t = useTranslations('Mypage');
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value);
+
+    if (value > 1000) {
+      toast.error(t('line-set-error'));
+      return;
+    }
+
+    props.onChange(e);
+  };
+
+  return <TextField type="number" name={props.name} id={props.name} value={props.value} onChange={onChange} />;
+}

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/OneType.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/OneType.tsx
@@ -1,73 +1,20 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useTranslations } from 'next-intl';
 import { css } from '_panda/css';
-import { flex } from '_panda/patterns';
-import { Button, TextField } from '@gitanimals/ui-panda';
-import { toast } from 'sonner';
 
-import { getGitanimalsLineString, GitanimalsLine } from '@/components/Gitanimals';
-import { useClientUser } from '@/utils/clientAuth';
-import { copyClipBoard } from '@/utils/copy';
-
-import { SelectPersonaList } from '../PersonaList';
-
-const DEFAULT_SIZE = { width: 600, height: 120 };
+import { LinePersonaSelect } from './LinePersonaSelect';
+import { LinePreview } from './LinePreview';
 
 interface Props {}
 
 export function OneType({}: Props) {
-  const t = useTranslations('Mypage');
-
-  const { name } = useClientUser();
-
-  const [selectPersona, setSelectPersona] = useState<string | null>();
-  const [sizes, setSizes] = useState<{ width: number; height: number }>(DEFAULT_SIZE);
-  const [isExtend, setIsExtend] = useState(false);
-
-  const onLinkCopy = async () => {
-    try {
-      await copyClipBoard(
-        getGitanimalsLineString({
-          username: name,
-          petId: selectPersona ?? undefined,
-          sizes: [sizes.width, sizes.height],
-        }),
-      );
-
-      toast.success('복사 성공!', { duration: 2000 });
-    } catch (error) {}
-  };
+  const [selectPersona, setSelectPersona] = useState<string | null>(null);
 
   return (
     <div className={sectionContianer}>
-      <section className={selectPetContainerStyle}>
-        <h2 className="heading">{t('change-pet')}</h2>
-        <Button className="extend-button" onClick={() => setIsExtend((prev) => !prev)}>
-          {isExtend ? t('shrink-button') : t('extend-button')}
-        </Button>
-      </section>
-
-      <section className={isExtend ? flexGrowSectionStyle : ''}>
-        <SelectPersonaList
-          name={name}
-          selectPersona={selectPersona ? [selectPersona] : []}
-          onSelectPersona={(persona) => setSelectPersona(persona.id)}
-          isExtend={isExtend}
-        />
-      </section>
-
-      {/* TODO: 임시로 모바일에선 input 안보이게 처리 */}
-      <SizeInputList onApply={(width, height) => setSizes({ width, height })} />
-      <section>
-        <div className={lineContainerStyle} style={{ width: sizes.width, height: sizes.height }}>
-          <GitanimalsLine sizes={[sizes.width, sizes.height]} petId={selectPersona} />
-        </div>
-        <Button onClick={onLinkCopy} mt={16} size="m">
-          {t('copy-link-title')}
-        </Button>
-      </section>
+      <LinePersonaSelect selectPersona={selectPersona} onChangePersona={(personaId) => setSelectPersona(personaId)} />
+      <LinePreview selectPersona={selectPersona} />
     </div>
   );
 }
@@ -87,91 +34,3 @@ const sectionContianer = css({
     borderRadius: 0,
   },
 });
-
-const flexGrowSectionStyle = css({
-  flex: '1',
-  minHeight: '0',
-  overflow: 'auto',
-  display: 'flex',
-  flexWrap: 'wrap',
-});
-
-const selectPetContainerStyle = css({
-  position: 'relative',
-  '& .heading': {
-    textStyle: 'glyph18.bold',
-    color: 'white',
-    marginBottom: '16px',
-  },
-  '& .extend-button': {
-    position: 'absolute',
-    top: '-16px',
-    right: 0,
-  },
-});
-
-const lineContainerStyle = css({
-  width: '100%',
-  background: 'white',
-  height: '100%',
-  transition: 'all 0.3s',
-  maxWidth: '1000px',
-  borderRadius: '12px',
-
-  '& img': {
-    maxWidth: '100%',
-  },
-  _mobile: {
-    maxWidth: '100%',
-  },
-});
-
-function SizeInputList({ onApply }: { onApply: (width: number, height: number) => void }) {
-  const t = useTranslations('Mypage');
-
-  const [width, setWidth] = useState(DEFAULT_SIZE.width);
-  const [height, setHeight] = useState(DEFAULT_SIZE.height);
-
-  return (
-    <div className={sizeInputStyle}>
-      <h2 className="heading">{t('customize-size')}</h2>
-      <div className={flex({ gap: 12 })}>
-        <SizeInput value={width} onChange={(e) => setWidth(parseInt(e.target.value))} name="width" />
-        <SizeInput value={height} onChange={(e) => setHeight(parseInt(e.target.value))} name="height" />
-        <Button onClick={() => onApply(width, height)}>{t('apply-button')}</Button>
-      </div>
-    </div>
-  );
-}
-
-const sizeInputStyle = css({
-  position: 'relative',
-  mt: 24,
-
-  '& .heading': {
-    textStyle: 'glyph18.bold',
-    color: 'white',
-    marginBottom: '16px',
-  },
-
-  _mobile: {
-    display: 'none',
-  },
-});
-
-function SizeInput(props: { value: number; onChange: (e: React.ChangeEvent<HTMLInputElement>) => void; name: string }) {
-  const t = useTranslations('Mypage');
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = parseInt(e.target.value);
-
-    if (value > 1000) {
-      toast.error(t('line-set-error'));
-      return;
-    }
-
-    props.onChange(e);
-  };
-
-  return <TextField type="number" name={props.name} id={props.name} value={props.value} onChange={onChange} />;
-}

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/OneType.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/OneType.tsx
@@ -6,20 +6,18 @@ import { css } from '_panda/css';
 import { LinePersonaSelect } from './LinePersonaSelect';
 import { LinePreview } from './LinePreview';
 
-interface Props {}
-
-export function OneType({}: Props) {
+export function LineType() {
   const [selectPersona, setSelectPersona] = useState<string | null>(null);
 
   return (
-    <div className={sectionContianer}>
+    <div className={sectionContainer}>
       <LinePersonaSelect selectPersona={selectPersona} onChangePersona={(personaId) => setSelectPersona(personaId)} />
       <LinePreview selectPersona={selectPersona} />
     </div>
   );
 }
 
-const sectionContianer = css({
+const sectionContainer = css({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',

--- a/apps/web/src/app/[locale]/mypage/(github-custom)/page.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/page.tsx
@@ -1,13 +1,14 @@
+import type { ReactNode } from 'react';
 import { css, cx } from '_panda/css';
 import { flex } from '_panda/patterns';
-import { ReactNode } from 'react';
-import { FarmType } from './FarmType';
-import { OneType } from './OneType';
 import { updateUrlSearchParams } from '@gitanimals/util-common';
 
 import { Link } from '@/i18n/routing';
 
-type TabType = '1-type' | 'farm-type';
+import { FarmType } from './FarmType';
+import { LineType } from './OneType';
+
+type TabType = 'line-type' | 'farm-type';
 
 async function Mypage({
   searchParams,
@@ -16,18 +17,18 @@ async function Mypage({
     type?: TabType;
   };
 }) {
-  const selectedType = searchParams?.type ?? '1-type';
+  const selectedType = searchParams?.type ?? 'line-type';
 
   const MYPAGE_TAB_INNER_MAP: Record<TabType, ReactNode> = {
-    '1-type': <OneType />,
+    'line-type': <LineType />,
     'farm-type': <FarmType />,
   };
 
   return (
     <>
       <div className={tabListStyle}>
-        <Link href={`/mypage?${updateUrlSearchParams(searchParams, 'type', '1-type')}`}>
-          <button className={cx('tab-item', selectedType === '1-type' && 'selected')}>1 Type</button>
+        <Link href={`/mypage?${updateUrlSearchParams(searchParams, 'type', 'line-type')}`}>
+          <button className={cx('tab-item', selectedType === 'line-type' && 'selected')}>1 Type</button>
         </Link>
         <Link href={`/mypage?${updateUrlSearchParams(searchParams, 'type', 'farm-type')}`}>
           <button className={cx('tab-item', selectedType === 'farm-type' && 'selected')}>Farm Type</button>

--- a/apps/web/src/app/[locale]/mypage/PersonaList.tsx
+++ b/apps/web/src/app/[locale]/mypage/PersonaList.tsx
@@ -10,10 +10,10 @@ import { BannerSkeleton } from '@gitanimals/ui-panda/src/components/Banner/Banne
 import { wrap } from '@suspensive/react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
+import { useClientUser } from '@/utils/clientAuth';
 import { getPersonaImage } from '@/utils/image';
 
 interface Props {
-  name: string;
   isExtend: boolean;
   selectPersona: string[];
   onSelectPersona: (persona: Persona) => void;
@@ -45,13 +45,13 @@ export const SelectPersonaList = wrap
   })
 
   .on(function SelectPersonaList({
-    name,
     isExtend,
     selectPersona,
     onSelectPersona,
     initSelectPersonas,
     loadingPersona,
   }: Props) {
+    const { name } = useClientUser();
     const { data } = useSuspenseQuery(userQueries.allPersonasOptions(name));
 
     // 초기 선택 로직, 외부에서 초기화 함수 전달

--- a/apps/web/src/app/[locale]/mypage/my-pet/page.tsx
+++ b/apps/web/src/app/[locale]/mypage/my-pet/page.tsx
@@ -6,21 +6,19 @@ import { useTranslations } from 'next-intl';
 import { css, cx } from '_panda/css';
 import { center, flex } from '_panda/patterns';
 import { dropPet, type Persona } from '@gitanimals/api';
+import { userQueries } from '@gitanimals/react-query';
 import { Button } from '@gitanimals/ui-panda';
 import { snakeToTitleCase } from '@gitanimals/util-common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { ANIMAL_TIER_TEXT_MAP, getAnimalTierInfo } from '@/utils/animals';
-import { useClientUser } from '@/utils/clientAuth';
 import { getPersonaImage } from '@/utils/image';
 
 import { SelectPersonaList } from '../PersonaList';
-import { userQueries } from '@gitanimals/react-query';
 
 function MypageMyPets() {
   const t = useTranslations('Mypage');
-  const { name } = useClientUser();
   const [selectPersona, setSelectPersona] = useState<Persona | null>(null);
 
   return (
@@ -37,7 +35,6 @@ function MypageMyPets() {
             })}
           >
             <SelectPersonaList
-              name={name}
               selectPersona={selectPersona ? [selectPersona.id] : []}
               onSelectPersona={(persona) => setSelectPersona(persona)}
               isExtend


### PR DESCRIPTION
# 💡 기능
제곧내


# 🔎 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- `FarmPersonaSelect` 및 `LinePersonaSelect` 컴포넌트 추가: 사용자가 페르소나를 선택할 수 있는 기능 제공.
	- `LinePreview` 컴포넌트 추가: 선택한 애완동물의 라인 표현을 사용자 맞춤형으로 미리보기 가능.
- **Bug Fixes**
	- `SelectPersonaList`에서 사용자 이름을 prop에서 훅 기반 접근으로 변경하여 성능 개선.
- **Refactor**
	- `FarmType` 및 `OneType` 컴포넌트의 구조 간소화 및 상태 관리 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->