### PR TITLE
Heading으로 스크롤 이동

### DIFF
--- a/apps/web/src/app/[locale]/shop/BackgroundSection/BackgroundSection.tsx
+++ b/apps/web/src/app/[locale]/shop/BackgroundSection/BackgroundSection.tsx
@@ -4,6 +4,7 @@
 import { useTranslations } from 'next-intl';
 import { css, cx } from '_panda/css';
 import type { Background } from '@gitanimals/api';
+import { useScrollHeading } from '@gitanimals/react';
 import { renderUserQueries, shopQueries, useBuyBackground } from '@gitanimals/react-query';
 import { Button } from '@gitanimals/ui-panda';
 import { wrap } from '@suspensive/react';
@@ -20,6 +21,9 @@ export const BackgroundSection = wrap
   })
   .Suspense({ fallback: <></> })
   .on(function BackgroundSection() {
+    // url에 '#background'라는 해쉬값이 있으면 아래 h2 태그로 스크롤되는 이벤트 처리
+    const backgroundRef = useScrollHeading('background');
+
     const t = useTranslations('Shop.Background');
     const { name } = useClientUser();
     const {
@@ -55,7 +59,9 @@ export const BackgroundSection = wrap
 
     return (
       <div className={sectionCss}>
-        <h2 className={h2Css}>Background</h2>
+        <h2 ref={backgroundRef} className={h2Css}>
+          Background
+        </h2>
         <div className={contentCss}>
           {backgroundList?.map((item) => (
             <BackgroundItem

--- a/apps/web/src/components/NoticeToast/notice.tsx
+++ b/apps/web/src/components/NoticeToast/notice.tsx
@@ -58,7 +58,7 @@ export const NOTICE_LIST = [
     closeButton: false,
     visible: true,
     redirect: {
-      url: '/shop',
+      url: '/shop#background',
       label: 'go',
     },
   },

--- a/packages/lib/react/src/hooks/index.ts
+++ b/packages/lib/react/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useOutsideClick';
 export * from './useBodyLock';
+export * from './useScrollHeading';

--- a/packages/lib/react/src/hooks/useScrollHeading/index.ts
+++ b/packages/lib/react/src/hooks/useScrollHeading/index.ts
@@ -1,0 +1,1 @@
+export * from './useScrollHeading';

--- a/packages/lib/react/src/hooks/useScrollHeading/useScrollHeading.ts
+++ b/packages/lib/react/src/hooks/useScrollHeading/useScrollHeading.ts
@@ -1,0 +1,26 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * URL 해시값과 일치하는 제목 요소로 스크롤하는 훅
+ * @param hash - 제목 요소의 hash 값
+ * @returns 제목 요소에 연결할 ref 객체
+ * @example
+ * ```tsx
+ * function Component() {
+ *   const headingRef = useScrollHeading('section-1');
+ *   return <h2 ref={headingRef}>Section 1</h2>
+ * }
+ * ```
+ */
+export const useScrollHeading = (hash: string, options?: ScrollIntoViewOptions) => {
+  const ref = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    const _hash = window.location.hash;
+    if (_hash === `#${hash}`) {
+      ref.current?.scrollIntoView({ behavior: 'smooth', ...options });
+    }
+  }, []);
+
+  return ref;
+};


### PR DESCRIPTION
# 💡 기능
url에 해당하는 해쉬값이 있다면 해당 heading 위치로 스크롤 이동하는 훅을 구현 후 적용하였습니다. 
상점 페이지 하단에 있는 `background` 섹션으로 바로 이동하게 하기 위해 추가하였어요. 

# 🔎 기타
