### PR TITLE
README.md Line Type 이미지 태그 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ GitAnimals 펫들을 쉽게 페이지에서 관리하고, 펫을 뽑을 수 있�
 
 <a href="https://github.com/devxb/gitanimals">
   <img
-
     src="https://render.gitanimals.org/lines/sumi-0011"
     width="600"
     height="120"
-
   />
 </a>
   


### PR DESCRIPTION
# 💡 기능
안녕하세요 🙇🏽‍♂️😇
git-animal-client 리포지토리의 README.md 파일에 
Line Type 하위에 이미지 태그가 빈 줄로 인해 코드로 인식되는 문제가 있어서 해결했습니다.

<img width="917" alt="image" src="https://github.com/user-attachments/assets/13caf4ea-05c8-4af0-b4a6-ffc461cd3159">

# 🔎 기타
이 밖에도 readme.md에 삽입된 gitanimals가 정상적으로 로딩되지 않고 있습니다.

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/fdeea13f-6418-41e5-8972-d3f951151f7b">

[제대로 불러와지지 않는 이미지 소스](https://camo.githubusercontent.com/ce1dc6c3d412855c57d6956f4ed758c675b01fa082c5dc90a39ee1f41ceebad3/68747470733a2f2f72656e6465722e676974616e696d616c732e6f72672f6661726d732f6b756e73616e676c6565)에 직접 접근해보니 아래와 같이 페이지가 제대로 랜더링 되지 않고 있었습니다.

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/e147e3f2-fb3c-4d42-98af-b6d5ef6832ff">

그런데, 개인 리포지토리의 readme.md에 삽입된 코드에 [이미지 소스](https://render.gitanimals.org/farms/kunsanglee)로 직접 접근했을 때는 정상적으로 이미지가 로딩되고 있습니다.

```html
<a href="https://github.com/devxb/gitanimals">
<img
  src="https://render.gitanimals.org/farms/kunsanglee"
  width="900"
  height="450"
/>
</a>
```

제 추측에는 아마도 [camo.githubusercontent.com](https://camo.githubusercontent.com/ce1dc6c3d412855c57d6956f4ed758c675b01fa082c5dc90a39ee1f41ceebad3/68747470733a2f2f72656e6465722e676974616e696d616c732e6f72672f6661726d732f6b756e73616e676c6565) 프록시로 GET 요청하여 받아오는 과정에 문제가 생긴 것으로 의심되는데, 이후로는 확인이 불가능하여 확인한 부분까지 말씀드립니다 🙇🏽‍♂️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
	- README.md 파일에 영어 번역 추가: GitAnimals 애완동물 기능 설명을 한국어에서 영어로 번역하여 영어 사용자의 이해를 돕습니다.
	- 애완동물 획득, GitHub 활동을 통한 성장, 애완동물 거래 기능에 대한 설명이 영어로 업데이트되었습니다.
	- "Line Type" 및 "Farm Type" 섹션 헤더는 변경되지 않았으며, 관련 이미지 태그에서 불필요한 줄 바꿈이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->