### PR TITLE
style: 랜딩 수치 영역 스타일 개선

### DIFF
--- a/apps/web/src/app/[locale]/landing/AvailablePetSection/AvailablePetSection.style.ts
+++ b/apps/web/src/app/[locale]/landing/AvailablePetSection/AvailablePetSection.style.ts
@@ -1,5 +1,5 @@
 import { css } from '_panda/css';
-import { flex, grid } from '_panda/patterns';
+import { flex } from '_panda/patterns';
 
 export const container = flex({
   padding: '120px 0',
@@ -37,22 +37,27 @@ export const heading = css({
   },
 });
 
-export const infoContainer = grid({
-  gap: '120px',
-  padding: '40px 70px',
-  gridTemplateColumns: 'repeat(3, 1fr)',
-  maxWidth: '767px',
+export const infoContainer = flex({
+  gap: '60px',
+  padding: '40px 52px',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  maxWidth: '766px',
+  w: '100%',
   background: 'white_10',
   borderRadius: '16px',
 
   _mobile: {
+    flexDir: 'column',
     maxWidth: 'calc(100% - 40px)',
-    gap: '44px',
+    gap: '12px',
     padding: '24px',
   },
 });
 
 export const infoItem = css({
+  width: 'fit-content',
+
   '& p': {
     _first: {
       textStyle: 'glyph48.bold',
@@ -61,6 +66,7 @@ export const infoItem = css({
         textStyle: 'glyph24.bold',
       },
     },
+
     _last: {
       textStyle: 'glyph18.bold',
       color: 'white_50',


### PR DESCRIPTION
# 💡 기능

# 🔎 기타
![스크린샷 2024-12-24 오후 10 16 15](https://github.com/user-attachments/assets/48ea8bf7-cd5b-49d3-86c0-abd1d03d9d7a)

![스크린샷 2024-12-24 오후 10 16 33](https://github.com/user-attachments/assets/6012f39c-c378-4340-8ed6-dff1f2fe1014)

여기 깨지는 거 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일 변경**
	- `AvailablePetSection`의 레이아웃 전략을 그리드에서 플렉스박스로 변경.
	- `infoContainer`의 패딩 및 간격 조정.
	- 모바일 스타일 업데이트: `infoContainer`의 방향을 열(column)로 설정하고 최대 너비 및 간격 조정.
	- `infoItem`에 `fit-content` 너비 속성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->