### PR TITLE
fix: 최신화 안되는 쿼리 개선

### DIFF
--- a/apps/web/src/apis/QueryClientProvider.tsx
+++ b/apps/web/src/apis/QueryClientProvider.tsx
@@ -9,7 +9,6 @@ const queryClientOption: QueryClientConfig = {
   defaultOptions: {
     queries: {
       retry: false,
-      refetchOnMount: false,
       refetchOnWindowFocus: false,
       staleTime: 1000,
     },

--- a/apps/web/src/app/[locale]/shop/AuctionSection/SellSection/PetList.tsx
+++ b/apps/web/src/app/[locale]/shop/AuctionSection/SellSection/PetList.tsx
@@ -1,12 +1,12 @@
 import Image from 'next/image';
 import { css } from '_panda/css';
 import type { Persona } from '@gitanimals/api';
+import { userQueries } from '@gitanimals/react-query';
 import { Banner } from '@gitanimals/ui-panda';
 import { useQuery } from '@tanstack/react-query';
 
 import { useClientUser } from '@/utils/clientAuth';
 import { getPersonaImage } from '@/utils/image';
-import { userQueries } from '@gitanimals/react-query';
 
 interface Props {
   selectedPersona?: Persona | null;

--- a/apps/web/src/app/[locale]/shop/AuctionSection/SellSection/SellInputRow.tsx
+++ b/apps/web/src/app/[locale]/shop/AuctionSection/SellSection/SellInputRow.tsx
@@ -39,7 +39,7 @@ function SellInputRow({ item, initPersona }: Props) {
   const { mutate } = useRegisterProduct({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: userQueries.allPersonasKey() });
-      queryClient.invalidateQueries({ queryKey: auctionQueries.myProductsKey() });
+      queryClient.removeQueries({ queryKey: auctionQueries.myProductsKey() });
 
       initPersona();
       resetPrice();

--- a/apps/web/src/app/[locale]/shop/AuctionSection/SellSection/SellInputRow.tsx
+++ b/apps/web/src/app/[locale]/shop/AuctionSection/SellSection/SellInputRow.tsx
@@ -39,7 +39,7 @@ function SellInputRow({ item, initPersona }: Props) {
   const { mutate } = useRegisterProduct({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: userQueries.allPersonasKey() });
-      queryClient.removeQueries({ queryKey: auctionQueries.myProductsKey() });
+      queryClient.invalidateQueries({ queryKey: auctionQueries.myProductsKey() });
 
       initPersona();
       resetPrice();

--- a/apps/web/src/app/[locale]/shop/SellListSection/EditModal.tsx
+++ b/apps/web/src/app/[locale]/shop/SellListSection/EditModal.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { css } from '_panda/css';
-import { auctionQueries, useChangeProductPrice, useDeleteProduct } from '@gitanimals/react-query';
+import { auctionQueries, useChangeProductPrice, useDeleteProduct, userQueries } from '@gitanimals/react-query';
 import { Button, Dialog } from '@gitanimals/ui-panda';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -18,16 +18,24 @@ function EditModal({ isOpen, onClose, productId }: { isOpen: boolean; onClose: (
     onSuccess: () => {
       onClose();
       queryClient.invalidateQueries({
-        queryKey: auctionQueries.myProductsKey(),
+        queryKey: auctionQueries.allKey(),
       });
+      queryClient.resetQueries({
+        queryKey: userQueries.allPersonasKey(),
+      });
+      console.log('delete');
     },
   });
 
   const { mutate: changePriceMutate } = useChangeProductPrice({
     onSuccess: () => {
+      console.log('asdfasdfsadfsf');
       onClose();
       queryClient.invalidateQueries({
-        queryKey: auctionQueries.myProductsKey(),
+        queryKey: auctionQueries.allKey(),
+      });
+      queryClient.resetQueries({
+        queryKey: userQueries.allPersonasKey(),
       });
     },
   });

--- a/apps/web/src/app/[locale]/shop/SellListSection/EditModal.tsx
+++ b/apps/web/src/app/[locale]/shop/SellListSection/EditModal.tsx
@@ -20,21 +20,19 @@ function EditModal({ isOpen, onClose, productId }: { isOpen: boolean; onClose: (
       queryClient.invalidateQueries({
         queryKey: auctionQueries.allKey(),
       });
-      queryClient.resetQueries({
+      queryClient.invalidateQueries({
         queryKey: userQueries.allPersonasKey(),
       });
-      console.log('delete');
     },
   });
 
   const { mutate: changePriceMutate } = useChangeProductPrice({
     onSuccess: () => {
-      console.log('asdfasdfsadfsf');
       onClose();
       queryClient.invalidateQueries({
         queryKey: auctionQueries.allKey(),
       });
-      queryClient.resetQueries({
+      queryClient.invalidateQueries({
         queryKey: userQueries.allPersonasKey(),
       });
     },

--- a/apps/web/src/app/[locale]/shop/SellListSection/index.tsx
+++ b/apps/web/src/app/[locale]/shop/SellListSection/index.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { Product } from '@gitanimals/api';
+import { auctionQueries } from '@gitanimals/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import Pagination from '@/components/Pagination';
 import ShopTableRowView, { ShopTableRowViewSkeleton } from '@/components/ProductTable/ShopTableRowView';
@@ -11,8 +13,6 @@ import { ACTION_BUTTON_OBJ } from '@/constants/action';
 import { tableCss, tbodyCss, theadCss } from '../AuctionSection/table.styles';
 
 import EditModal from './EditModal';
-import { useQuery } from '@tanstack/react-query';
-import { auctionQueries } from '@gitanimals/react-query';
 
 const SELL_LIST_ACTION_OBJ = ACTION_BUTTON_OBJ['EDIT'];
 

--- a/packages/ui/panda/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/panda/src/components/Dialog/Dialog.tsx
@@ -44,7 +44,6 @@ const Title = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ children, ...props }, ref) => {
-  console.log('props: ', props);
   return (
     <DialogPrimitive.Title ref={ref} {...props} className={cx('dialog-title', titleStyle, props.className)}>
       {children}


### PR DESCRIPTION
# 💡 기능

- 한 번 sell list를 본 후, 새롭게 판매하는 경우 sell list가 갱신되지 않음
  - invalidate는 하고 있으나, `refetchOnMount`의 기본 설정이 false라 재요청하지 않음

https://stackoverflow.com/questions/76670546/invalidate-all-queries-but-refetch-only-active

# 🔎 기타

- resetQuries로 해도 되지만, 개발자가 인지해야하는 것을 줄이는 것이 나은 선택이라 판단함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - `PetList` 및 `EditModal` 컴포넌트에서 사용자 관련 쿼리 기능 추가.
  
- **버그 수정**
  - `EditModal`에서 제품 관련 쿼리 무효화 키 업데이트 및 모든 사용자 페르소나 무효화 추가.

- **문서화**
  - `Dialog` 모듈에서 불필요한 콘솔 로그 제거로 성능 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->