### PR TITLE
실험실 - 다중 판매 문구 변경

### DIFF
--- a/apps/web/messages/en_US.json
+++ b/apps/web/messages/en_US.json
@@ -141,7 +141,10 @@
     "property-pet-sell": {
       "title": "Property Pet Sell",
       "description": "Sell your pet to other users!",
-      "count": "ea"
+      "count": "ea",
+      "saleSuccess": "sale success",
+      "saleFail": "sale fail",
+      "totalAmount": "Total Amount"
     }
   },
   "Inbox": {

--- a/apps/web/messages/ko_KR.json
+++ b/apps/web/messages/ko_KR.json
@@ -141,9 +141,12 @@
   },
   "Laboratory": {
     "property-pet-sell": {
-      "title": "Property Pet Sell",
-      "description": "Sell your pet to other users!",
-      "count": "개"
+      "title": "펫 판매",
+      "description": "보유한 펫을 판매해보세요!",
+      "count": "개",
+      "saleSuccess": "판매 완료",
+      "saleFail": "판매 실패",
+      "totalAmount": "총 판매 금액"
     }
   },
   "Inbox": {

--- a/apps/web/src/app/[locale]/laboratory/property-pet-sell/page.tsx
+++ b/apps/web/src/app/[locale]/laboratory/property-pet-sell/page.tsx
@@ -48,11 +48,48 @@ const PersonaList = wrap
         onConfirm: () => onSell(ids),
       });
     };
+    const DropPetsResult = ({ success, errors }: { success: { givenPoint: number }[]; errors: unknown[] }) => {
+      const totalPrice = success.reduce((acc, curr) => acc + curr.givenPoint, 0);
+      const hasSuccess = success.length > 0;
+      const hasErrors = errors.length > 0;
+
+      if (hasSuccess && hasErrors) {
+        return (
+          <div>
+            <p>
+              {success.length}마리 판매 완료, {errors.length}마리 판매 실패
+            </p>
+            <p>총 판매 금액: {totalPrice}P</p>
+          </div>
+        );
+      }
+
+      if (hasSuccess) {
+        return (
+          <div>
+            <p>{success.length}마리 판매 완료</p>
+            <p>총 판매 금액: {totalPrice}P</p>
+          </div>
+        );
+      }
+
+      if (hasErrors) {
+        return (
+          <div>
+            <p>{errors.length}마리 판매 실패</p>
+          </div>
+        );
+      }
+
+      return (
+        <div>
+          <p>0마리 판매 완료, 0마리 판매 실패</p>
+        </div>
+      );
+    };
 
     const onSell = async (ids: string[]) => {
       const res = await dropPets({ personaIds: ids });
-
-      const totalPrice = res.success.reduce((acc, curr) => acc + curr.givenPoint, 0);
 
       trackEvent('laboratory', {
         type: '레벨, 타입 같은 펫 한번에 팔기',
@@ -62,14 +99,7 @@ const PersonaList = wrap
 
       showDialog({
         title: '펫 판매 완료',
-        description: (
-          <div>
-            <p>
-              {res.success.length}마리 판매 완료, {res.errors.length}마리 판매 실패
-            </p>
-            <p>총 판매 금액: {totalPrice}P</p>
-          </div>
-        ),
+        description: <DropPetsResult success={res.success} errors={res.errors} />,
       });
     };
 

--- a/apps/web/src/app/[locale]/laboratory/property-pet-sell/page.tsx
+++ b/apps/web/src/app/[locale]/laboratory/property-pet-sell/page.tsx
@@ -48,42 +48,57 @@ const PersonaList = wrap
         onConfirm: () => onSell(ids),
       });
     };
-    const DropPetsResult = ({ success, errors }: { success: { givenPoint: number }[]; errors: unknown[] }) => {
-      const totalPrice = success.reduce((acc, curr) => acc + curr.givenPoint, 0);
-      const hasSuccess = success.length > 0;
-      const hasErrors = errors.length > 0;
 
-      if (hasSuccess && hasErrors) {
+    const DropPetsResult = ({ success, errors }: { success: { givenPoint: number }[]; errors: unknown[] }) => {
+      const t = useTranslations('Laboratory.property-pet-sell');
+
+      if (success.length === 0 && errors.length === 0) {
         return (
           <div>
             <p>
-              {success.length}마리 판매 완료, {errors.length}마리 판매 실패
+              0{t('count')} {t('saleSuccess')}, 0{t('count')} {t('saleFail')}
             </p>
-            <p>총 판매 금액: {totalPrice}P</p>
           </div>
         );
       }
 
-      if (hasSuccess) {
+      if (success.length === 0) {
         return (
           <div>
-            <p>{success.length}마리 판매 완료</p>
-            <p>총 판매 금액: {totalPrice}P</p>
+            <p>
+              {errors.length}
+              {t('count')} {t('saleFail')}
+            </p>
           </div>
         );
       }
 
-      if (hasErrors) {
+      const totalPrice = success.reduce((acc, curr) => acc + curr.givenPoint, 0);
+
+      if (errors.length === 0) {
         return (
           <div>
-            <p>{errors.length}마리 판매 실패</p>
+            <p>
+              {success.length}
+              {t('count')} {t('saleSuccess')}
+            </p>
+            <p>
+              {t('totalAmount')}: {totalPrice}P
+            </p>
           </div>
         );
       }
 
       return (
         <div>
-          <p>0마리 판매 완료, 0마리 판매 실패</p>
+          <p>
+            {success.length}
+            {t('count')} {t('saleSuccess')}, {errors.length}
+            {t('count')} {t('saleFail')}
+          </p>
+          <p>
+            {t('totalAmount')}: {totalPrice}P
+          </p>
         </div>
       );
     };

--- a/apps/web/src/app/[locale]/laboratory/property-pet-sell/page.tsx
+++ b/apps/web/src/app/[locale]/laboratory/property-pet-sell/page.tsx
@@ -52,22 +52,30 @@ const PersonaList = wrap
     const DropPetsResult = ({ success, errors }: { success: { givenPoint: number }[]; errors: unknown[] }) => {
       const t = useTranslations('Laboratory.property-pet-sell');
 
-      if (success.length === 0 && errors.length === 0) {
+      const successLength = success.length;
+      const errorLength = errors.length;
+
+      const count = t('count');
+      const saleSuccess = t('saleSuccess');
+      const saleFail = t('saleFail');
+      const totalAmount = t('totalAmount');
+
+      if (successLength === 0 && errorLength === 0) {
         return (
           <div>
             <p>
-              0{t('count')} {t('saleSuccess')}, 0{t('count')} {t('saleFail')}
+              0{count} {saleSuccess}, 0{count} {saleFail}
             </p>
           </div>
         );
       }
 
-      if (success.length === 0) {
+      if (successLength === 0) {
         return (
           <div>
             <p>
-              {errors.length}
-              {t('count')} {t('saleFail')}
+              {errorLength}
+              {count} {saleFail}
             </p>
           </div>
         );
@@ -75,15 +83,15 @@ const PersonaList = wrap
 
       const totalPrice = success.reduce((acc, curr) => acc + curr.givenPoint, 0);
 
-      if (errors.length === 0) {
+      if (errorLength === 0) {
         return (
           <div>
             <p>
-              {success.length}
-              {t('count')} {t('saleSuccess')}
+              {successLength}
+              {count} {saleSuccess}
             </p>
             <p>
-              {t('totalAmount')}: {totalPrice}P
+              {totalAmount}: {totalPrice}P
             </p>
           </div>
         );
@@ -92,12 +100,12 @@ const PersonaList = wrap
       return (
         <div>
           <p>
-            {success.length}
-            {t('count')} {t('saleSuccess')}, {errors.length}
-            {t('count')} {t('saleFail')}
+            {successLength}
+            {count} {saleSuccess}, {errorLength}
+            {count} {saleFail}
           </p>
           <p>
-            {t('totalAmount')}: {totalPrice}P
+            {totalAmount}: {totalPrice}P
           </p>
         </div>
       );


### PR DESCRIPTION
# 💡 기능
* 실험실 다중 판매를 이용하는 과정에서, 실패하지 않았음에도 `xx마리 판매 실패` 라는 문구가 등장하며 사용자에게 혼란을 제공
* 판매 성공 여부에 따라 등장 하는 문구를 조정 , 모두 실패했을 경우 판매액에 대한 정보를 제공하지 않음 

# 🔎 기타
* 판매 상태에 대한 다이얼로그가 화면에 떠있는 시간이 굉장히 짧음, 등장 타임을 조정 or 버튼을 통해 사용자가 직접 끌 수 있도록 조정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 반려동물 판매 결과를 표시하는 새로운 `DropPetsResult` 컴포넌트 추가
	- 판매 성공 및 실패에 대한 상세 정보를 사용자에게 직관적으로 보여줌
	- 판매 결과의 시각화 및 정보 제공 개선
	- 한국어 지원 추가: 판매 성공, 실패 및 총 판매 금액에 대한 메시지 번역
- **문서화**
	- 영어 및 한국어 메시지 파일에 새로운 키 추가 및 기존 키 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->