### PR TITLE
feat: preview link에 utm 링크 걸기

### DIFF
--- a/apps/web/src/components/Gitanimals.tsx
+++ b/apps/web/src/components/Gitanimals.tsx
@@ -2,6 +2,12 @@
 
 import { useClientUser } from '@/utils/clientAuth';
 
+const GITANIMALS_URL = 'https://www.gitanimals.org/en_US';
+
+const getLink = (props: { username: string; type: 'farm' | 'line' }) => {
+  return `${GITANIMALS_URL}?utm_medium=image&utm_source=${props.username}&utm_content=${props.type}`;
+};
+
 interface GitanimalsLineProps {
   sizes?: [number, number];
   petId?: string | null;
@@ -13,7 +19,7 @@ export function GitanimalsLine({ petId, sizes = [600, 120] }: GitanimalsLineProp
   const pet = petId ? `?pet-id=${petId}` : '';
 
   return (
-    <a href="https://github.com/devxb/gitanimals">
+    <a href={getLink({ username, type: 'line' })}>
       <img
         src={`https://render.gitanimals.org/lines/${username}${pet}`}
         width={sizes[0]}
@@ -32,7 +38,7 @@ export const getGitanimalsLineString = ({
   const pet = petId ? `?pet-id=${petId}` : '';
 
   return `
-<a href="https://github.com/devxb/gitanimals">
+<a href="${getLink({ username, type: 'line' })}">
   <img
     src="https://render.gitanimals.org/lines/${username}${pet}"
     width="${sizes[0]}"
@@ -56,7 +62,7 @@ interface FarmImageProps extends GitanimalsFarmProps {
 export function GitanimalsFarm({ sizes = [600, 300], imageKey }: FarmImageProps) {
   const { name: username } = useClientUser();
   return (
-    <a href="https://github.com/devxb/gitanimals">
+    <a href={getLink({ username, type: 'farm' })}>
       <img
         src={`https://render.gitanimals.org/farms/${username}?${imageKey}`}
         width={sizes[0]}
@@ -75,7 +81,7 @@ interface FarmStringProps extends GitanimalsFarmProps {
 }
 
 export const getGitanimalsFarmString = ({ username, sizes = [600, 300] }: FarmStringProps) => {
-  return `<a href="https://github.com/devxb/gitanimals">
+  return `<a href="${getLink({ username, type: 'farm' })}">
 <img
   src="https://render.gitanimals.org/farms/${username}"
   width="${sizes[0]}"


### PR DESCRIPTION
# 💡 기능
- 어느 경로로 서비스에 유입되는지 확인하기 위한 방식으로 utm link를 추가해보았습니다. 
# 🔎 기타
<a href="https://www.gitanimals.org/en_US?utm_medium=image&utm_source=sumi-0011&utm_content=farm">
<img
  src="https://render.gitanimals.org/farms/sumi-0011"
  width="600"
  height="300"
/>
</a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Gitanimals URL 생성 로직 개선
	- 동적 링크 생성을 위한 새로운 함수 추가
	- 사용자 이름과 타입에 따른 유연한 URL 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->