### PR TITLE
fix: Persona 타입 불일치에 따른 물품 금액 수정 오류 해결

### DIFF
--- a/packages/api/src/auction/changeProduct.ts
+++ b/packages/api/src/auction/changeProduct.ts
@@ -1,12 +1,19 @@
 import z from 'zod';
-import { PersonaSchema } from '../render';
 import { safePatch } from '../_instance/safe';
 
+const ChangeProductPersonaSchema = z.object({
+  personaId: z.string(),
+  personaType: z.string(),
+  personaLevel: z.number(),
+});
+
 const ChangeProductResponseSchema = z.object({
+  id: z.string(),
   sellerId: z.string(),
-  persona: PersonaSchema,
+  persona: ChangeProductPersonaSchema,
   price: z.string(),
   paymentState: z.string(),
+  receipt: z.string().nullable(),
 });
 
 const ChangeProductRequestSchema = z.object({


### PR DESCRIPTION
## 개요

- `문제원인` : API Response 타입 불일치
- `문제해결` : 현재 상황에 맞게 타입 수정

## 설명

현재 가격 변경 api의 응답으로 받고 있는 인터페이스는 이렇습니다.

```json
{
    "id": "699145768673778032",
    "sellerId": "585486216865728938",
    "persona": {
        "personaId": "672685740624448762",
        "personaType": "LITTLE_CHICK",
        "personaLevel": 17
    },
    "price": "30000",
    "paymentState": "ON_SALE",
    "receipt": null
}
```

그런데 프론트에서는 이렇게 받을 거라고 기대하고 있었어요.

```ts
{
  sellerId: string;
  persona: {
    id: string;
    type: string;
    level: string;
    visible: boolean;
    dropRate: string;
  },
  price: string;
  paymentState: string;
}
```

특히 persona 부분이 많이 다른데, `페르소나 리스트 조회`, `페르소나 수정`에서 같은 Persona 인터페이스를 쓰면 안 되는데 공용으로 쓰고 있더라고요. 가설은 이렇습니다.

1. 원래는 같은 Persona 인터페이스를 썼는데 중간에 서버에서 두 인터페이스를 구분했다. 그리고 프론트에서 대응이 안됐다.
2. 원래부터 달랐는데 프론트 개발에서 공용으로 사용했고, 오류를 인지하지 못했다.

https://github.com/git-goods/gitanimals-api/blob/main/docs/api/auction/change_product.md