### PR TITLE
fix: pet merge dialog window cannot scroll when width > 768px

### DIFF
--- a/packages/ui/panda/src/components/Dialog/Dialog.styles.ts
+++ b/packages/ui/panda/src/components/Dialog/Dialog.styles.ts
@@ -13,7 +13,6 @@ export const dialogContentCva = cva({
     size: {
       default: {
         display: 'flex',
-        height: '100%',
         width: '100%',
         flexDirection: 'column',
         justifyContent: 'center',
@@ -38,7 +37,7 @@ export const dialogContentCva = cva({
         maxWidth: 'calc(100% - 400px)',
         maxHeight: 'calc(100% - 240px)',
         width: '100%',
-        height: 'fit-content',
+        height: '100%',
 
         '@media (max-width: 1200px)': {
           padding: '48px 24px',

--- a/packages/ui/panda/src/components/Dialog/Dialog.styles.ts
+++ b/packages/ui/panda/src/components/Dialog/Dialog.styles.ts
@@ -13,6 +13,7 @@ export const dialogContentCva = cva({
     size: {
       default: {
         display: 'flex',
+        height: '100%',
         width: '100%',
         flexDirection: 'column',
         justifyContent: 'center',


### PR DESCRIPTION
# 💡 기능
#318 
- Dialog default css에 `height: 100%` 추가하였습니다.

# 🔎 기타
- localhost dev mode에서 login이 안 되고, auth error 경로로 리디렉션이 많이 되는데 혹시 어떻게 auth 필요한 테스트를 진행하나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Style**
	- 기본 다이얼로그 콘텐츠의 높이가 100%로 설정되어 세로 공간을 완전히 채우도록 개선되었습니다. (단, max-height에 의해 제한받습니다.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->