### PR TITLE
Rank Pagination 추가

### DIFF
--- a/apps/web/src/apis/QueryClientProvider.tsx
+++ b/apps/web/src/apis/QueryClientProvider.tsx
@@ -1,35 +1,18 @@
 'use client';
 
-import type { PropsWithChildren } from 'react';
-import type { QueryClientConfig } from '@tanstack/react-query';
-import { QueryClient, QueryClientProvider as BaseQueryClientProvider } from '@tanstack/react-query';
+import { type PropsWithChildren } from 'react';
+import { QueryClientProvider as BaseQueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { toast } from 'sonner';
 
-const queryClientOption: QueryClientConfig = {
-  defaultOptions: {
-    queries: {
-      retry: false,
-      refetchOnWindowFocus: false,
-      staleTime: 1000,
-      throwOnError: true,
-    },
-    mutations: {
-      throwOnError: true,
-      onError: (_error) => {
-        toast.error('something went wrong 😭');
-      },
-    },
-  },
-};
-
-const queryClient = new QueryClient(queryClientOption);
+import { getQueryClient } from '@/lib/react-query/queryClient';
 
 const QueryClientProvider = ({ children }: PropsWithChildren) => {
+  const queryClient = getQueryClient();
+
   return (
     <BaseQueryClientProvider client={queryClient}>
       {children}
-      <ReactQueryDevtools />
+      {process.env.NODE_ENV === 'development' && <ReactQueryDevtools />}
     </BaseQueryClientProvider>
   );
 };

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -1,14 +1,18 @@
+import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
+import Flicking from '@egjs/react-flicking';
 import type { RankType } from '@gitanimals/api';
 import { getNewUrl } from '@gitanimals/util-common';
 
-import { PaginationServer } from '@/components/Pagination/PaginationServer';
-
 import { RankingLink } from './RankingLink';
 
-export function RankingTable({ ranks, page, totalPage }: { page: number; ranks: RankType[]; totalPage: number }) {
+import '@egjs/react-flicking/dist/flicking.css';
+import '@egjs/flicking-plugins/dist/pagination.css';
+
+export function MobileRankingTable({ ranks, page, totalPage }: { page: number; ranks: RankType[]; totalPage: number }) {
+  const router = useRouter();
   const { data: session } = useSession();
   const searchParams = useSearchParams();
   const currentUsername = session?.user?.name;
@@ -16,6 +20,17 @@ export function RankingTable({ ranks, page, totalPage }: { page: number; ranks: 
   const getRankingPageUrl = (params: Record<string, unknown>) => {
     const oldParams = Object.fromEntries(searchParams.entries());
     return getNewUrl({ baseUrl: '/test/ranking', newParams: params, oldParams });
+  };
+
+  const handleMoveEnd = (e: any) => {
+    const direction = e.direction;
+    const newPage = direction === 'NEXT' ? page - 1 : page + 1;
+
+    if (newPage < 0) return;
+    if (newPage > totalPage) return;
+
+    const newUrl = getRankingPageUrl({ page: newPage });
+    router.push(newUrl);
   };
 
   // 페이지 데이터를 10개씩 그룹화
@@ -30,49 +45,66 @@ export function RankingTable({ ranks, page, totalPage }: { page: number; ranks: 
 
   return (
     <div className={rankingListStyle}>
-      {groupedRanks.map((group, index) => (
-        <div key={index} className={slideStyle}>
-          <table className={tableStyle}>
-            <thead>
-              <tr className={theadTrStyle}>
-                <th>Rank</th>
-                <th>Pet</th>
-                <th>Name</th>
-                <th>Contribution</th>
-              </tr>
-            </thead>
-            <tbody>
-              {group.map((item) => (
-                <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
-                  <td>{item.rank}</td>
-                  <td>
-                    <RankingLink id={item.name}>
-                      <img src={item.image} alt={item.name} width={60} height={60} />
-                    </RankingLink>
-                  </td>
-                  <td>
-                    <RankingLink id={item.name}>{item.name}</RankingLink>
-                  </td>
-                  <td>{item.contributions}</td>
+      <Flicking
+        className={flickingStyle}
+        defaultIndex={page - 1}
+        circular={false}
+        moveType="strict"
+        bound={true}
+        renderOnlyVisible={true}
+        onMoveEnd={handleMoveEnd}
+      >
+        {groupedRanks.map((group, index) => (
+          <div key={index} className={slideStyle}>
+            <table className={tableStyle}>
+              <thead>
+                <tr className={theadTrStyle}>
+                  <th>Rank</th>
+                  <th>Pet</th>
+                  <th>Name</th>
+                  <th>Contribution</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ))}
+              </thead>
+              <tbody>
+                {group.map((item) => (
+                  <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
+                    <td>{item.rank}</td>
+                    <td>
+                      <RankingLink id={item.name}>
+                        <img src={item.image} alt={item.name} width={60} height={60} />
+                      </RankingLink>
+                    </td>
+                    <td>
+                      <RankingLink id={item.name}>{item.name}</RankingLink>
+                    </td>
+                    <td>{item.contributions}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+      </Flicking>
       <div className={paginationStyle}>
-        <PaginationServer
-          totalRecords={totalPage}
-          currentPage={page}
-          totalPages={totalPage}
-          nextPage={page === totalPage ? null : page + 1}
-          prevPage={page < 1 ? null : page - 1}
-          generateMoveLink={getRankingPageUrl}
-        />
+        {[0, 1, 2].map((group, index) => {
+          const isActive =
+            (page === 0 && index === 0) ||
+            (page !== 0 && page !== totalPage && index === 1) ||
+            (page === totalPage && index === 2);
+          return <div key={index} className={cx(paginationBulletStyle, isActive && 'active')}></div>;
+        })}
       </div>
     </div>
   );
 }
+
+const flickingStyle = css({
+  width: '100%',
+  height: 'auto',
+  margin: '0 auto',
+  position: 'relative',
+  overflow: 'hidden',
+});
 
 const slideStyle = css({
   width: '100%',
@@ -90,6 +122,18 @@ const paginationStyle = css({
   alignItems: 'center',
   justifyContent: 'center',
   gap: 2,
+});
+
+const paginationBulletStyle = css({
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+  backgroundColor: 'white.white_50',
+  cursor: 'pointer',
+
+  '&.active': {
+    backgroundColor: 'white.white_100',
+  },
 });
 
 const rankingListStyle = css({

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
@@ -35,7 +35,6 @@ export default function RankingSection({
   });
 
   const totalPage = calcTotalPage(queries[2].data?.count ?? 0);
-  console.log('totalPage: ', totalPage);
 
   if (queries[0].isLoading || queries[1].isLoading || !queries[0].data || !queries[1].data) {
     return <div></div>;

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams } from 'next/navigation';
 import { css, cx } from '_panda/css';
+import type { GetRanksResponse } from '@gitanimals/api';
 
 import { MediaQuery } from '@/components/MediaQuery';
 import { Link } from '@/i18n/routing';
@@ -11,7 +12,13 @@ import { MobileGameConsole } from './MobileGameConsole/MobileGameConsole';
 import { RankingTable } from './RankingTable';
 import { TopPodium } from './TopPodium';
 
-export default function RankingSection({ data: ranks }: { data: any }) {
+export default function RankingSection({
+  topRanks,
+  bottomRanks,
+}: {
+  topRanks: GetRanksResponse;
+  bottomRanks: GetRanksResponse;
+}) {
   const searchParams = useSearchParams();
   const selectedTab = searchParams.get('ranking') ?? 'people';
 
@@ -22,24 +29,20 @@ export default function RankingSection({ data: ranks }: { data: any }) {
       <MediaQuery
         desktop={
           <GameConsole>
-            {ranks && (
-              <div className={screenContentStyle}>
-                <RankingTab selectedTab={selectedTab} />
-                <TopPodium ranks={ranks.slice(0, 3)} />
-                <RankingTable ranks={ranks.slice(3)} />
-              </div>
-            )}
+            <div className={screenContentStyle}>
+              <RankingTab selectedTab={selectedTab} />
+              <TopPodium ranks={topRanks} />
+              <RankingTable ranks={bottomRanks} />
+            </div>
           </GameConsole>
         }
         mobile={
-          ranks && (
-            <div className={screenContentStyle}>
-              <RankingTab selectedTab={selectedTab} />
-              <TopPodium ranks={ranks.slice(0, 3)} />
-              <RankingTable ranks={ranks.slice(3)} />
-              <MobileGameConsole />
-            </div>
-          )
+          <div className={screenContentStyle}>
+            <RankingTab selectedTab={selectedTab} />
+            <TopPodium ranks={topRanks} />
+            <RankingTable ranks={bottomRanks} />
+            <MobileGameConsole />
+          </div>
         }
       />
     </div>

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
@@ -10,6 +10,7 @@ import { Link } from '@/i18n/routing';
 
 import GameConsole from './GameConsole/GameConsole';
 import { MobileGameConsole } from './MobileGameConsole/MobileGameConsole';
+import { MobileRankingTable } from './MobileRankingTable';
 import { RankingTable } from './RankingTable';
 import { TopPodium } from './TopPodium';
 
@@ -29,8 +30,12 @@ export default function RankingSection({
     queries: [
       rankQueries.getRanksOptions({ rank: 1, size: 3, type }),
       rankQueries.getRanksOptions({ rank: startRankNumber, size: 5, type }),
+      rankQueries.getTotalRankOptions({ type }),
     ],
   });
+
+  const totalPage = calcTotalPage(queries[2].data?.count ?? 0);
+  console.log('totalPage: ', totalPage);
 
   if (queries[0].isLoading || queries[1].isLoading || !queries[0].data || !queries[1].data) {
     return <div></div>;
@@ -46,7 +51,7 @@ export default function RankingSection({
             <div className={screenContentStyle}>
               <RankingTab selectedTab={selectedTab} />
               <TopPodium ranks={queries[0].data} />
-              <RankingTable ranks={queries[1].data} page={page} />
+              <RankingTable ranks={queries[1].data} page={page} totalPage={totalPage} />
             </div>
           </GameConsole>
         }
@@ -54,7 +59,7 @@ export default function RankingSection({
           <div className={screenContentStyle}>
             <RankingTab selectedTab={selectedTab} />
             <TopPodium ranks={queries[0].data} />
-            <RankingTable ranks={queries[1].data} page={page} />
+            <MobileRankingTable ranks={queries[1].data} page={page} totalPage={totalPage} />
             <MobileGameConsole />
           </div>
         }
@@ -62,6 +67,11 @@ export default function RankingSection({
     </div>
   );
 }
+
+const calcTotalPage = (totalCount: number) => {
+  if (totalCount <= 3) return 0;
+  return Math.ceil((totalCount - 3) / 5) - 1;
+};
 
 const titleStyle = css({
   textStyle: 'glyph82.bold',

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
@@ -15,13 +15,13 @@ import { RankingTable } from './RankingTable';
 import { TopPodium } from './TopPodium';
 
 export default function RankingSection({
-  page,
   type,
   startRankNumber,
+  currentPage,
 }: {
-  page: number;
   type: 'WEEKLY_USER_CONTRIBUTIONS' | 'WEEKLY_GUILD_CONTRIBUTIONS';
   startRankNumber: number;
+  currentPage: number;
 }) {
   const searchParams = useSearchParams();
   const selectedTab = searchParams.get('ranking') ?? 'people';
@@ -50,7 +50,7 @@ export default function RankingSection({
             <div className={screenContentStyle}>
               <RankingTab selectedTab={selectedTab} />
               <TopPodium ranks={queries[0].data} />
-              <RankingTable ranks={queries[1].data} page={page} totalPage={totalPage} />
+              <RankingTable ranks={queries[1].data} page={currentPage} totalPage={totalPage} />
             </div>
           </GameConsole>
         }
@@ -58,7 +58,7 @@ export default function RankingSection({
           <div className={screenContentStyle}>
             <RankingTab selectedTab={selectedTab} />
             <TopPodium ranks={queries[0].data} />
-            <MobileRankingTable ranks={queries[1].data} page={page} totalPage={totalPage} />
+            <MobileRankingTable ranks={queries[1].data} page={currentPage} totalPage={totalPage} />
             <MobileGameConsole />
           </div>
         }

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
@@ -14,11 +14,13 @@ import { RankingTable } from './RankingTable';
 import { TopPodium } from './TopPodium';
 
 export default function RankingSection({
-  startRankNumber,
+  page,
   type,
+  startRankNumber,
 }: {
-  startRankNumber: number;
+  page: number;
   type: 'WEEKLY_USER_CONTRIBUTIONS' | 'WEEKLY_GUILD_CONTRIBUTIONS';
+  startRankNumber: number;
 }) {
   const searchParams = useSearchParams();
   const selectedTab = searchParams.get('ranking') ?? 'people';
@@ -44,7 +46,7 @@ export default function RankingSection({
             <div className={screenContentStyle}>
               <RankingTab selectedTab={selectedTab} />
               <TopPodium ranks={queries[0].data} />
-              <RankingTable ranks={queries[1].data} />
+              <RankingTable ranks={queries[1].data} page={page} />
             </div>
           </GameConsole>
         }
@@ -52,7 +54,7 @@ export default function RankingSection({
           <div className={screenContentStyle}>
             <RankingTab selectedTab={selectedTab} />
             <TopPodium ranks={queries[0].data} />
-            <RankingTable ranks={queries[1].data} />
+            <RankingTable ranks={queries[1].data} page={page} />
             <MobileGameConsole />
           </div>
         }

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingTable.tsx
@@ -62,9 +62,9 @@ export function RankingTable({ ranks, page, totalPage }: { page: number; ranks: 
       ))}
       <div className={paginationStyle}>
         <PaginationServer
-          totalRecords={totalPage}
           currentPage={page}
-          totalPages={totalPage}
+          totalRecords={totalPage + 1}
+          totalPages={totalPage + 1}
           nextPage={page === totalPage ? null : page + 1}
           prevPage={page < 1 ? null : page - 1}
           generateMoveLink={getRankingPageUrl}

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingTable.tsx
@@ -1,12 +1,22 @@
+import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
 import type { RankType } from '@gitanimals/api';
+import { getNewUrl } from '@gitanimals/util-common';
+
+import { PaginationServer } from '@/components/Pagination/PaginationServer';
 
 import { RankingLink } from './RankingLink';
 
-export function RankingTable({ ranks }: { ranks: RankType[] }) {
+export function RankingTable({ ranks, page }: { page: number; ranks: RankType[] }) {
   const { data: session } = useSession();
+  const searchParams = useSearchParams();
   const currentUsername = session?.user?.name;
+
+  const getRankingPageUrl = (params: Record<string, unknown>) => {
+    const oldParams = Object.fromEntries(searchParams.entries());
+    return getNewUrl({ baseUrl: '/test/ranking', newParams: params, oldParams });
+  };
 
   return (
     <div className={rankingListStyle}>
@@ -36,6 +46,14 @@ export function RankingTable({ ranks }: { ranks: RankType[] }) {
           ))}
         </tbody>
       </table>
+      <PaginationServer
+        totalRecords={100} // TODO: 서버 데이터 필요
+        currentPage={page}
+        totalPages={100}
+        nextPage={page + 1}
+        prevPage={page - 1}
+        generateMoveLink={getRankingPageUrl}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingTable.tsx
@@ -46,17 +46,23 @@ export function RankingTable({ ranks, page }: { page: number; ranks: RankType[] 
           ))}
         </tbody>
       </table>
-      <PaginationServer
-        totalRecords={100} // TODO: 서버 데이터 필요
-        currentPage={page}
-        totalPages={100}
-        nextPage={page + 1}
-        prevPage={page - 1}
-        generateMoveLink={getRankingPageUrl}
-      />
+      <div className={paginationStyle}>
+        <PaginationServer
+          totalRecords={100} // TODO: 서버 데이터 필요
+          currentPage={page}
+          totalPages={100}
+          nextPage={page + 1}
+          prevPage={page - 1}
+          generateMoveLink={getRankingPageUrl}
+        />
+      </div>
     </div>
   );
 }
+
+const paginationStyle = css({
+  marginTop: '24px',
+});
 
 const rankingListStyle = css({});
 

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingTable.tsx
@@ -1,9 +1,13 @@
+import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
 import type { RankType } from '@gitanimals/api';
 
 import { RankingLink } from './RankingLink';
 
 export function RankingTable({ ranks }: { ranks: RankType[] }) {
+  const { data: session } = useSession();
+  const currentUsername = session?.user?.name;
+
   return (
     <div className={rankingListStyle}>
       <table className={tableStyle}>
@@ -17,7 +21,7 @@ export function RankingTable({ ranks }: { ranks: RankType[] }) {
         </thead>
         <tbody>
           {ranks.map((item) => (
-            <tr key={item.rank} className={trStyle}>
+            <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
               <td>{item.rank}</td>
               <td>
                 <RankingLink id={item.name}>
@@ -129,3 +133,8 @@ const trStyle = cx(
     },
   }),
 );
+
+const currentUserTrStyle = css({
+  background:
+    'linear-gradient(133deg, rgba(255, 253, 201, 0.30) 2.19%, rgba(150, 230, 216, 0.30) 49.24%, rgba(125, 171, 241, 0.30) 98.21%)',
+});

--- a/apps/web/src/app/[locale]/test/ranking/page.tsx
+++ b/apps/web/src/app/[locale]/test/ranking/page.tsx
@@ -45,7 +45,7 @@ export default async function TestRankingPage({
 
     return (
       <Hydrate state={{ queries }}>
-        <RankingSection page={currentPage} type={rankType} startRankNumber={startRankNumber} />
+        <RankingSection type={rankType} startRankNumber={startRankNumber} currentPage={currentPage} />
       </Hydrate>
     );
   } catch (error) {

--- a/apps/web/src/app/[locale]/test/ranking/page.tsx
+++ b/apps/web/src/app/[locale]/test/ranking/page.tsx
@@ -29,7 +29,7 @@ export default async function TestRankingPage({
         return currentPage;
       }
 
-      return 4;
+      return 0;
     };
 
     const currentPage = searchParams.page ? Number(searchParams.page) : await getStartPageNumber();

--- a/apps/web/src/app/[locale]/test/ranking/page.tsx
+++ b/apps/web/src/app/[locale]/test/ranking/page.tsx
@@ -25,14 +25,14 @@ export default async function TestRankingPage({
         const rankByUsername = await getRankByUsername(session.user.name);
         const currentUserRank = rankByUsername.rank;
 
-        const currentPage = Math.ceil((currentUserRank - RANKS_TOP_3) / RANKS_PER_PAGE);
+        const currentPage = Math.ceil((currentUserRank - RANKS_TOP_3) / RANKS_PER_PAGE) - 1;
         return currentPage;
       }
 
       return 4;
     };
 
-    const currentPage = Number(searchParams.page) ?? (await getStartPageNumber());
+    const currentPage = searchParams.page ? Number(searchParams.page) : await getStartPageNumber();
     const startRankNumber = currentPage * RANKS_PER_PAGE + 4;
 
     const rankType = type === 'people' ? 'WEEKLY_USER_CONTRIBUTIONS' : 'WEEKLY_GUILD_CONTRIBUTIONS';

--- a/apps/web/src/app/[locale]/test/ranking/page.tsx
+++ b/apps/web/src/app/[locale]/test/ranking/page.tsx
@@ -20,20 +20,21 @@ export default async function TestRankingPage({
 
     const session = await getServerSession();
 
-    const getRankStartNumber = async () => {
+    const getStartPageNumber = async () => {
       if (session && type === 'people') {
         const rankByUsername = await getRankByUsername(session.user.name);
         const currentUserRank = rankByUsername.rank;
 
         const currentPage = Math.ceil((currentUserRank - RANKS_TOP_3) / RANKS_PER_PAGE);
-        const startRankNumber = currentPage * RANKS_PER_PAGE + 1;
-        return startRankNumber;
+        return currentPage;
       }
 
       return 4;
     };
 
-    const startRankNumber = await getRankStartNumber();
+    const currentPage = Number(searchParams.page) ?? (await getStartPageNumber());
+    const startRankNumber = currentPage * RANKS_PER_PAGE + 4;
+
     const rankType = type === 'people' ? 'WEEKLY_USER_CONTRIBUTIONS' : 'WEEKLY_GUILD_CONTRIBUTIONS';
 
     const queries = await getDehydratedQueries([
@@ -43,7 +44,7 @@ export default async function TestRankingPage({
 
     return (
       <Hydrate state={{ queries }}>
-        <RankingSection startRankNumber={startRankNumber} type={rankType} />
+        <RankingSection page={currentPage} type={rankType} startRankNumber={startRankNumber} />
       </Hydrate>
     );
   } catch (error) {

--- a/apps/web/src/app/[locale]/test/ranking/page.tsx
+++ b/apps/web/src/app/[locale]/test/ranking/page.tsx
@@ -1,18 +1,44 @@
-import { getRanks } from '@gitanimals/api';
+import { getServerSession } from 'next-auth';
+import { getRankByUsername, getRanks } from '@gitanimals/api';
 
 import RankingSection from '../../landing/RankingSection/RankingSection';
+
+const TOTAL_VIEW_RANKS = 8 as const;
+const RANKS_TOP_3 = 3 as const;
+const RANKS_PER_PAGE = TOTAL_VIEW_RANKS - RANKS_TOP_3;
 
 export default async function TestRankingPage({
   searchParams,
 }: {
   searchParams: { [key: string]: string | string[] | undefined };
 }) {
-  const type = searchParams.ranking ?? 'people';
+  try {
+    const type = searchParams.ranking ?? 'people';
 
-  const data = await getRanks({
-    rank: 1,
-    size: 8,
-    type: type === 'people' ? 'WEEKLY_USER_CONTRIBUTIONS' : 'WEEKLY_GUILD_CONTRIBUTIONS',
-  });
-  return <RankingSection data={data} />;
+    const session = await getServerSession();
+
+    const rankType = type === 'people' ? 'WEEKLY_USER_CONTRIBUTIONS' : 'WEEKLY_GUILD_CONTRIBUTIONS';
+
+    if (!session) {
+      const data = await getRanks({ rank: 1, size: TOTAL_VIEW_RANKS, type: rankType });
+
+      return <RankingSection topRanks={data.slice(0, 3)} bottomRanks={data.slice(3)} />;
+    }
+
+    const rankByUsername = await getRankByUsername(session.user.name);
+    const currentUserRank = rankByUsername.rank;
+
+    if (currentUserRank <= 3) {
+      const data = await getRanks({ rank: 1, size: TOTAL_VIEW_RANKS, type: rankType });
+
+      return <RankingSection topRanks={data} bottomRanks={data} />;
+    }
+
+    const topRanks = await getRanks({ rank: 1, size: RANKS_TOP_3, type: rankType });
+    const currentUserRankData = await getRanks({ rank: currentUserRank, size: RANKS_PER_PAGE, type: rankType });
+
+    return <RankingSection topRanks={topRanks} bottomRanks={currentUserRankData} />;
+  } catch (error) {
+    return <></>;
+  }
 }

--- a/apps/web/src/app/[locale]/test/ranking/page.tsx
+++ b/apps/web/src/app/[locale]/test/ranking/page.tsx
@@ -40,6 +40,7 @@ export default async function TestRankingPage({
     const queries = await getDehydratedQueries([
       rankQueries.getRanksOptions({ rank: 1, size: RANKS_TOP_3, type: rankType }),
       rankQueries.getRanksOptions({ rank: startRankNumber, size: RANKS_PER_PAGE, type: rankType }),
+      rankQueries.getTotalRankOptions({ type: rankType }),
     ]);
 
     return (

--- a/apps/web/src/components/Pagination/PaginationServer.tsx
+++ b/apps/web/src/components/Pagination/PaginationServer.tsx
@@ -17,15 +17,17 @@ export function PaginationServer(props: { generateMoveLink: (props: { page: numb
 
   return (
     <div className={paginationContainerStyle}>
-      <Link
-        href={props.generateMoveLink({ page: props.prevPage ?? 0 })}
-        style={{
-          pointerEvents: props.prevPage === null ? 'none' : 'auto',
-          cursor: props.prevPage === null ? 'not-allowed' : 'pointer',
-        }}
-      >
-        <ChevronLeft color="#B5B8C0" />
-      </Link>
+      {props.prevPage !== null && (
+        <Link
+          href={props.generateMoveLink({ page: props.prevPage })}
+          style={{
+            pointerEvents: props.prevPage === null ? 'none' : 'auto',
+            cursor: props.prevPage === null ? 'not-allowed' : 'pointer',
+          }}
+        >
+          <ChevronLeft color="#B5B8C0" />
+        </Link>
+      )}
 
       {getPaginationGroup().map((i) => {
         return (
@@ -39,15 +41,17 @@ export function PaginationServer(props: { generateMoveLink: (props: { page: numb
         );
       })}
 
-      <Link
-        href={props.generateMoveLink({ page: props.nextPage ?? 0 })}
-        style={{
-          pointerEvents: props.nextPage === null ? 'none' : 'auto',
-          cursor: props.nextPage === null ? 'not-allowed' : 'pointer',
-        }}
-      >
-        <ChevronRight color="#B5B8C0" />
-      </Link>
+      {props.nextPage !== null && (
+        <Link
+          href={props.generateMoveLink({ page: props.nextPage })}
+          style={{
+            pointerEvents: props.nextPage === null ? 'none' : 'auto',
+            cursor: props.nextPage === null ? 'not-allowed' : 'pointer',
+          }}
+        >
+          <ChevronRight color="#B5B8C0" />
+        </Link>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/Pagination/PaginationServer.tsx
+++ b/apps/web/src/components/Pagination/PaginationServer.tsx
@@ -70,10 +70,12 @@ const paginationContainerStyle = css({
 
 const nonSelectedCss = css({
   textStyle: 'glyph16.regular',
+  lineHeight: '10px',
   color: 'white.white_50',
 });
 
 const selectedCss = css({
   textStyle: 'glyph16.bold',
+  lineHeight: '10px',
   color: 'white.white_100',
 });

--- a/apps/web/src/constants/route.ts
+++ b/apps/web/src/constants/route.ts
@@ -6,6 +6,7 @@ const GUILD = {
 };
 
 export const ROUTE = {
+  HOME: () => '/',
   GUILD,
 };
 

--- a/apps/web/src/lib/react-query/queryClient.ts
+++ b/apps/web/src/lib/react-query/queryClient.ts
@@ -1,0 +1,71 @@
+import type { QueryClientConfig, QueryKey, QueryState } from '@tanstack/react-query';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+const queryClientOption: QueryClientConfig = {
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+      staleTime: 1000,
+      throwOnError: true,
+    },
+    mutations: {
+      throwOnError: true,
+      onError: (_error) => {
+        toast.error('something went wrong 😭');
+      },
+    },
+  },
+};
+
+type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
+
+interface QueryProps<ResponseType = unknown> {
+  queryKey: QueryKey;
+  queryFn: () => Promise<ResponseType>;
+}
+
+interface DehydratedQueryExtended<TData = unknown, TError = unknown> {
+  state: QueryState<TData, TError>;
+}
+
+let queryClient: QueryClient | undefined;
+
+export const getQueryClient = () => {
+  if (typeof window === 'undefined') {
+    return new QueryClient(queryClientOption);
+  }
+
+  if (!queryClient) {
+    queryClient = new QueryClient(queryClientOption);
+  }
+
+  return queryClient;
+};
+
+export async function getDehydratedQuery<Q extends QueryProps>({ queryKey, queryFn }: Q) {
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery({ queryKey, queryFn });
+
+  const { queries } = dehydrate(queryClient);
+
+  const [dehydratedQuery] = queries.filter((query) => isEqual(query.queryKey, queryKey));
+
+  return dehydratedQuery as DehydratedQueryExtended<UnwrapPromise<ReturnType<Q['queryFn']>>>;
+}
+
+export const Hydrate = HydrationBoundary;
+
+const isEqual = (a: QueryKey, b: QueryKey) => {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+};
+
+export async function getDehydratedQueries<Q extends QueryProps[]>(queries: Q) {
+  const queryClient = getQueryClient();
+
+  await Promise.all(queries.map(({ queryKey, queryFn }) => queryClient.prefetchQuery({ queryKey, queryFn })));
+
+  return dehydrate(queryClient).queries as DehydratedQueryExtended<UnwrapPromise<ReturnType<Q[number]['queryFn']>>>[];
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -4,7 +4,7 @@ import createMiddleware from 'next-intl/middleware';
 
 import { routing } from './i18n/routing';
 
-const publicPages = ['/', '/auth', '/event/HALLOWEEN_2024', '/event/CHRISTMAS_2024'];
+const publicPages = ['/', '/auth', '/event/HALLOWEEN_2024', '/event/CHRISTMAS_2024', '/test/ranking'];
 
 const intlMiddleware = createMiddleware({
   ...routing,

--- a/packages/api/src/ranks/getRankByUsername.ts
+++ b/packages/api/src/ranks/getRankByUsername.ts
@@ -1,0 +1,16 @@
+import z from 'zod';
+import { renderGet } from '../_instance';
+
+const GetRankByUsernameResponseSchema = z.object({
+  id: z.string(),
+  rank: z.number(),
+  image: z.string(),
+  name: z.string(),
+  contributions: z.number(),
+});
+
+export type GetRankByUsernameResponse = z.infer<typeof GetRankByUsernameResponseSchema>;
+
+export const getRankByUsername = async (username: string) => {
+  return await renderGet<GetRankByUsernameResponse>(`/ranks/by-username/${username}`);
+};

--- a/packages/api/src/ranks/getTotalRank.ts
+++ b/packages/api/src/ranks/getTotalRank.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { safeRenderGet } from '../_instance/safe';
+
+const GetTotalRankRequestSchema = z.object({
+  type: z.enum(['WEEKLY_USER_CONTRIBUTIONS', 'WEEKLY_GUILD_CONTRIBUTIONS']),
+});
+
+const GetTotalRankResponseSchema = z.object({
+  count: z.number(),
+});
+
+export type GetTotalRankRequest = z.infer<typeof GetTotalRankRequestSchema>;
+export type GetTotalRankResponse = z.infer<typeof GetTotalRankResponseSchema>;
+
+export const getTotalRank = async (request: GetTotalRankRequest) => {
+  return await safeRenderGet(GetTotalRankResponseSchema)(`/ranks/total?type=${request.type}`);
+};

--- a/packages/api/src/ranks/index.ts
+++ b/packages/api/src/ranks/index.ts
@@ -1,2 +1,3 @@
 export * from './getRanks';
+export * from './getRankByUsername';
 export * from './types';

--- a/packages/api/src/ranks/index.ts
+++ b/packages/api/src/ranks/index.ts
@@ -1,3 +1,4 @@
 export * from './getRanks';
 export * from './getRankByUsername';
+export * from './getTotalRank';
 export * from './types';

--- a/packages/lib/react-query/src/rank/queries.ts
+++ b/packages/lib/react-query/src/rank/queries.ts
@@ -1,11 +1,19 @@
-import { getRanks, GetRanksRequest } from '@gitanimals/api';
-import { queryOptions } from '@tanstack/react-query';
+import { getRanks, GetRanksRequest, GetRanksResponse } from '@gitanimals/api';
+import { QueryKey, queryOptions, UndefinedInitialDataOptions } from '@tanstack/react-query';
+
+interface QueryProps<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> extends UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> {
+  queryFn: () => Promise<TQueryFnData>;
+}
 
 export const rankQueries = {
   allKey: () => ['rank'],
-  getRanksOptions: (request: GetRanksRequest) =>
-    queryOptions({
-      queryKey: [...rankQueries.allKey(), request],
-      queryFn: () => getRanks(request),
-    }),
+  getRanksOptions: (request: GetRanksRequest) => ({
+    queryKey: [...rankQueries.allKey(), request],
+    queryFn: () => getRanks(request),
+  }),
 };

--- a/packages/lib/react-query/src/rank/queries.ts
+++ b/packages/lib/react-query/src/rank/queries.ts
@@ -1,4 +1,4 @@
-import { getRanks, GetRanksRequest, GetRanksResponse } from '@gitanimals/api';
+import { getRanks, GetRanksRequest, GetRanksResponse, getTotalRank, GetTotalRankRequest } from '@gitanimals/api';
 import { QueryKey, queryOptions, UndefinedInitialDataOptions } from '@tanstack/react-query';
 
 interface QueryProps<
@@ -15,5 +15,9 @@ export const rankQueries = {
   getRanksOptions: (request: GetRanksRequest) => ({
     queryKey: [...rankQueries.allKey(), request],
     queryFn: () => getRanks(request),
+  }),
+  getTotalRankOptions: (request: GetTotalRankRequest) => ({
+    queryKey: [...rankQueries.allKey(), request],
+    queryFn: () => getTotalRank(request),
   }),
 };


### PR DESCRIPTION
# 💡 기능
- 랭크의 페이지네이션 기능을 추가하였습니다. 
- 모바일에는 slider를 통해 작동되도록 하였어요. 
- 모바일에서는 slider, pc에서는 페이지네이션으로 구성되어있어 컴포넌트를 분리했습니다. 이후 공통 부분은 리팩토링 할 예정이예요
# 🔎 기타
<img width="317" alt="image" src="https://github.com/user-attachments/assets/1c0cecc8-1dcf-4c13-8d65-7ddd6e73730b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 모바일에 최적화된 랭킹 테이블(MobileRankingTable) 컴포넌트가 추가되었습니다.
  - 랭킹 API에 사용자별 순위 조회 및 전체 랭킹 수 조회 기능이 추가되었습니다.
  - 새로운 홈 경로 상수가 추가되었습니다.

- **기능 개선**
  - 랭킹 섹션과 랭킹 테이블이 페이지네이션 및 사용자 세션 인식 기능을 지원하도록 개선되었습니다.
  - 랭킹 페이지가 사용자의 순위에 따라 시작 페이지를 자동으로 설정합니다.
  - 페이지네이션 UI 및 접근성이 개선되었습니다.
  - React Query 클라이언트 생성 및 쿼리 프리패치, 하이드레이션 로직이 모듈화되어 유지보수가 용이해졌습니다.
  - 개발 환경에서만 ReactQueryDevtools가 노출되도록 변경되었습니다.

- **버그 수정**
  - 페이지네이션에서 비활성화된 이전/다음 링크가 더 이상 렌더링되지 않습니다.

- **기타**
  - 공개 경로에 테스트 랭킹 페이지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->