### PR TITLE
랜딩 페이지 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ apps/web/public/sw.js
 
 *storybook.log
 .playwright-mcp
+
+# Local Claude Code instructions
+apps/*/CLAUDE.local.md
+CLAUDE.local.md

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,9 +1,3 @@
-# language of the project (csharp, python, rust, java, typescript, go, cpp, or ruby)
-#  * For C, use cpp
-#  * For JavaScript, use typescript
-# Special requirements:
-#  * csharp: Requires the presence of a .sln file in the project folder.
-language: typescript
 
 # whether to use the project's gitignore file to ignore files
 # Added on 2025-04-07
@@ -64,5 +58,81 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "git-animal-client"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: utf-8
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript

--- a/apps/web/messages/en_US.json
+++ b/apps/web/messages/en_US.json
@@ -245,6 +245,8 @@
   "Error": {
     "global-error-message": "Something went wrong 😭",
     "want-to-report-error": "The gitanimals development team is currently tracking this error.\nIf you have a moment, we would greatly appreciate it if you could report the circumstances that led to this error.",
-    "report-error-button": "Report Error"
+    "report-error-button": "Report Error",
+    "ranking-error-title": "Unable to load ranking information",
+    "ranking-error-description": "Please try again later"
   }
 }

--- a/apps/web/messages/ko_KR.json
+++ b/apps/web/messages/ko_KR.json
@@ -246,6 +246,8 @@
   "Error": {
     "global-error-message": "문제가 발생했어요 😭",
     "want-to-report-error": "gitanimals 개발팀은 현재 이 오류를 추적하고 있습니다.\n시간이 되신다면 이 오류가 발생한 상황을 보고해주시면 감사하겠습니다.",
-    "report-error-button": "오류 보고하기"
+    "report-error-button": "오류 보고하기",
+    "ranking-error-title": "랭킹 정보를 불러올 수 없습니다",
+    "ranking-error-description": "잠시 후 다시 시도해주세요"
   }
 }

--- a/apps/web/src/app/[locale]/landing/AvailablePetSection/AvailablePetSection.tsx
+++ b/apps/web/src/app/[locale]/landing/AvailablePetSection/AvailablePetSection.tsx
@@ -4,6 +4,7 @@ import React, { Suspense } from 'react';
 import Image from 'next/image';
 import { AnchorButton } from '@gitanimals/ui-panda';
 
+import { Responsive } from '@/components/Responsive';
 import { useGetTotalProductCount } from '@/hooks/query/auction/useGetTotalProductCount';
 import { useGetTotalIdentityUserCount } from '@/hooks/query/identity/useGetTotalIdentityUserCount';
 import { useGetTotalPersonaCount } from '@/hooks/query/render/useGetTotalPersonaCount';
@@ -54,12 +55,15 @@ function AvailablePetSection() {
         </div>
 
         <div className={styles.buttonWrapper}>
-          <AnchorButton size="m" className="mobile" target="_blank" href={MORE_PET_GITHUB_URL}>
+          <Responsive
+            component={AnchorButton}
+            desktop={{ size: 'l' }}
+            mobile={{ size: 'm' }}
+            target="_blank"
+            href={MORE_PET_GITHUB_URL}
+          >
             Show More Pets
-          </AnchorButton>
-          <AnchorButton size="l" className="desktop" target="_blank" href={MORE_PET_GITHUB_URL}>
-            Show More Pets
-          </AnchorButton>
+          </Responsive>
         </div>
       </div>
     </section>

--- a/apps/web/src/app/[locale]/landing/ChoosePetSection/ChoosePetSection.tsx
+++ b/apps/web/src/app/[locale]/landing/ChoosePetSection/ChoosePetSection.tsx
@@ -2,6 +2,7 @@ import { Button } from '@gitanimals/ui-panda';
 
 import { getServerAuth } from '@/auth';
 import { LoginButton } from '@/components/AuthButton';
+import { Responsive } from '@/components/Responsive';
 import { Link } from '@/i18n/routing';
 
 import * as styles from './ChoosePetSection.style';
@@ -22,12 +23,9 @@ async function ChoosePetSection() {
         <LoginButton label="Get a Pet" />
       ) : (
         <Link href="/mypage">
-          <Button className="desktop" size="l">
+          <Responsive component={Button} desktop={{ size: 'l' }} mobile={{ size: 'm' }}>
             Go To Mypage
-          </Button>
-          <Button className="mobile" size="m">
-            Go To Mypage
-          </Button>
+          </Responsive>
         </Link>
       )}
     </section>

--- a/apps/web/src/app/[locale]/landing/Footer/Footer.style.ts
+++ b/apps/web/src/app/[locale]/landing/Footer/Footer.style.ts
@@ -5,7 +5,7 @@ export const footer = css({
   display: 'flex',
   flexDir: 'column',
   gap: '120px',
-  // bg: 'black.black',
+  bg: 'black.black',
   width: '100%',
   color: 'white.white',
   padding: '120px 0',

--- a/apps/web/src/app/[locale]/landing/MainSection/MainSection.style.ts
+++ b/apps/web/src/app/[locale]/landing/MainSection/MainSection.style.ts
@@ -14,20 +14,6 @@ export const section = flex({
   _mobile: {
     padding: '80px 12px',
   },
-
-  '& .mobile': {
-    display: 'none',
-    _mobile: {
-      display: 'block',
-    },
-  },
-
-  '& .desktop': {
-    display: 'block',
-    _mobile: {
-      display: 'none',
-    },
-  },
 });
 
 export const heading = css({

--- a/apps/web/src/app/[locale]/landing/MainSection/MainSection.tsx
+++ b/apps/web/src/app/[locale]/landing/MainSection/MainSection.tsx
@@ -2,6 +2,7 @@ import { Button } from '@gitanimals/ui-panda';
 
 import { getServerAuth } from '@/auth';
 import { LoginButton } from '@/components/AuthButton';
+import { Responsive } from '@/components/Responsive';
 import { Link } from '@/i18n/routing';
 
 import * as styles from './MainSection.style';
@@ -17,17 +18,13 @@ async function MainSection() {
       <p className={styles.desc}>
         You can acquire and grow pets through GitHub activities. Choose from over 50 different pets and raise them.
       </p>
-      {/* TODO: button 반응형 처리 */}
       {!session ? (
         <LoginButton label="Get a Pet" />
       ) : (
         <Link href="/mypage">
-          <Button className="desktop" size="l">
+          <Responsive component={Button} desktop={{ size: 'l' }} mobile={{ size: 'm' }}>
             Go To Mypage
-          </Button>
-          <Button className="mobile" size="m">
-            Go To Mypage
-          </Button>
+          </Responsive>
         </Link>
       )}
       <div className={styles.bg} />

--- a/apps/web/src/app/[locale]/landing/MainSection/MainSlider.tsx
+++ b/apps/web/src/app/[locale]/landing/MainSection/MainSlider.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { css, cx } from '_panda/css';
-import type { ChangedEvent, FlickingOptions, FlickingProps } from '@egjs/react-flicking';
-import Flicking from '@egjs/react-flicking';
+import useEmblaCarousel from 'embla-carousel-react';
 
 import * as styles from './MainSlider.style';
 import SliderItem from './SliderItem';
@@ -26,47 +25,26 @@ const MODE_ITEM_LIST = [
 ];
 
 function MainSlider() {
-  const flicking = useRef<Flicking | null>(null);
+  const [emblaRef, emblaApi] = useEmblaCarousel({ align: 'start', containScroll: 'trimSnaps' });
   const [currentPanelIndex, setCurrentPanelIndex] = useState(0);
 
   const isFirstPanel = currentPanelIndex === 0;
   const isLastPanel = currentPanelIndex === MODE_ITEM_LIST.length - 1;
 
-  const onPanelIndexChange = (index: number) => {
-    if (!flicking.current) return;
-    if (flicking.current.animating) return;
-    flicking.current?.moveTo(index);
-  };
+  useEffect(() => {
+    if (!emblaApi) return;
 
-  const moveToNextPanel = async () => {
-    if (!flicking.current) return;
-    if (isLastPanel) return;
-    if (flicking.current.animating) return;
+    const onSelect = () => setCurrentPanelIndex(emblaApi.selectedScrollSnap());
+    onSelect();
+    emblaApi.on('select', onSelect);
+    return () => {
+      emblaApi.off('select', onSelect);
+    };
+  }, [emblaApi]);
 
-    try {
-      flicking.current.next();
-    } catch (error) {}
-  };
-
-  const moveToPrevPanel = async () => {
-    if (!flicking.current) return;
-    if (isFirstPanel) return;
-    if (flicking.current.animating) return;
-
-    try {
-      flicking.current.prev();
-    } catch (error) {}
-  };
-
-  const onPanelChanged = (e: ChangedEvent<Flicking>) => {
-    setCurrentPanelIndex(e.index);
-  };
-
-  // TODO: arrow plugin 으로 변경
-  const sliderOptions: Partial<FlickingProps & FlickingOptions> = {
-    panelsPerView: 1,
-    onChanged: onPanelChanged,
-  };
+  const onPanelIndexChange = (index: number) => emblaApi?.scrollTo(index);
+  const moveToNextPanel = () => emblaApi?.scrollNext();
+  const moveToPrevPanel = () => emblaApi?.scrollPrev();
 
   return (
     <div className={styles.container}>
@@ -85,13 +63,15 @@ function MainSlider() {
       <div className={styles.sliderContainer}>
         <ArrowButton onClick={moveToPrevPanel} direction="prev" disabled={isFirstPanel} />
         <ArrowButton onClick={moveToNextPanel} direction="next" disabled={isLastPanel} />
-        <Flicking ref={flicking} {...sliderOptions}>
-          {MODE_ITEM_LIST.map((item) => (
-            <div key={item.title} className={styles.sliderItem}>
-              <SliderItem item={item} />
-            </div>
-          ))}
-        </Flicking>
+        <div className={emblaViewportStyle} ref={emblaRef}>
+          <div className={emblaContainerStyle}>
+            {MODE_ITEM_LIST.map((item) => (
+              <div key={item.title} className={cx(styles.sliderItem, emblaSlideStyle)}>
+                <SliderItem item={item} />
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -170,3 +150,7 @@ const nextArrowStyle = cx(
     },
   }),
 );
+
+const emblaViewportStyle = css({ overflow: 'hidden', width: '100%' });
+const emblaContainerStyle = css({ display: 'flex' });
+const emblaSlideStyle = css({ flex: '0 0 100%', minWidth: 0 });

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -24,7 +24,13 @@ export function MobileRankingTable({ initialRanks, initialPage, totalPage, type 
   const { data: session } = useSession();
   const currentUsername = session?.user?.name;
   const [page, setPage] = useState(initialPage);
+  const [slideDirection, setSlideDirection] = useState<'left' | 'right' | null>(null);
   const touchStartX = useRef(0);
+
+  const goToPage = (next: number) => {
+    setSlideDirection(next > page ? 'left' : 'right');
+    setPage(next);
+  };
 
   const rankStart = page * RANKS_PER_PAGE + 4;
 
@@ -53,25 +59,28 @@ export function MobileRankingTable({ initialRanks, initialPage, totalPage, type 
     if (Math.abs(diff) < SWIPE_THRESHOLD) return;
 
     if (diff > 0 && page < totalPage) {
-      setPage((p) => p + 1);
+      goToPage(page + 1);
     } else if (diff < 0 && page > 0) {
-      setPage((p) => p - 1);
+      goToPage(page - 1);
     }
   };
 
   return (
     <div className={containerStyle} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
-      <div className={cx(tableWrapperStyle, isPlaceholderData && fetchingStyle)}>
+      <div
+        key={page}
+        className={cx(tableWrapperStyle, isPlaceholderData && fetchingStyle, slideDirection === 'left' && slideInFromRight, slideDirection === 'right' && slideInFromLeft)}
+      >
         <RankingTableView ranks={ranks} currentUsername={currentUsername} />
       </div>
       <div className={paginationStyle}>
-        <button className={arrowButtonStyle} onClick={() => setPage((p) => p - 1)} disabled={page <= 0} aria-label="이전 페이지">
+        <button className={arrowButtonStyle} onClick={() => goToPage(page - 1)} disabled={page <= 0} aria-label="이전 페이지">
           ‹
         </button>
         <span className={paginationTextStyle}>
           {page + 1} / {totalPage + 1}
         </span>
-        <button className={arrowButtonStyle} onClick={() => setPage((p) => p + 1)} disabled={page >= totalPage} aria-label="다음 페이지">
+        <button className={arrowButtonStyle} onClick={() => goToPage(page + 1)} disabled={page >= totalPage} aria-label="다음 페이지">
           ›
         </button>
       </div>
@@ -133,7 +142,7 @@ function RankingTableView({
   );
 }
 
-const containerStyle = css({ width: '100%' });
+const containerStyle = css({ width: '100%', overflow: 'hidden' });
 
 const tableWrapperStyle = css({
   transition: 'opacity 0.15s ease',
@@ -141,6 +150,14 @@ const tableWrapperStyle = css({
 
 const fetchingStyle = css({
   opacity: 0.5,
+});
+
+const slideInFromRight = css({
+  animation: 'slideFromRight 0.2s ease-out',
+});
+
+const slideInFromLeft = css({
+  animation: 'slideFromLeft 0.2s ease-out',
 });
 
 const paginationStyle = css({

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -1,37 +1,52 @@
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
-import Flicking from '@egjs/react-flicking';
+import useEmblaCarousel from 'embla-carousel-react';
 import type { RankType } from '@gitanimals/api';
 import { getNewUrl } from '@gitanimals/util-common';
 
 import { RankingLink } from './RankingLink';
-
-import '@egjs/react-flicking/dist/flicking.css';
-import '@egjs/flicking-plugins/dist/pagination.css';
 
 export function MobileRankingTable({ ranks, page, totalPage }: { page: number; ranks: RankType[]; totalPage: number }) {
   const router = useRouter();
   const { data: session } = useSession();
   const searchParams = useSearchParams();
   const currentUsername = session?.user?.name;
+  const prevIndexRef = useRef(page - 1);
+
+  const [emblaRef, emblaApi] = useEmblaCarousel({ startIndex: page - 1 });
 
   const getRankingPageUrl = (params: Record<string, unknown>) => {
     const oldParams = Object.fromEntries(searchParams.entries());
     return getNewUrl({ baseUrl: '/', newParams: params, oldParams });
   };
 
-  const handleMoveEnd = (e: any) => {
-    const direction = e.direction;
-    const newPage = direction === 'NEXT' ? page - 1 : page + 1;
+  useEffect(() => {
+    if (!emblaApi) return;
 
-    if (newPage < 0) return;
-    if (newPage > totalPage) return;
+    const onSelect = () => {
+      const currentIndex = emblaApi.selectedScrollSnap();
+      const previousIndex = prevIndexRef.current;
+      if (currentIndex === previousIndex) return;
+      prevIndexRef.current = currentIndex;
 
-    const newUrl = getRankingPageUrl({ page: newPage });
-    router.push(newUrl);
-  };
+      // Flicking NEXT(index 증가) → page - 1, PREV(index 감소) → page + 1
+      const newPage = currentIndex > previousIndex ? page - 1 : page + 1;
+
+      if (newPage < 0) return;
+      if (newPage > totalPage) return;
+
+      const newUrl = getRankingPageUrl({ page: newPage });
+      router.push(newUrl);
+    };
+
+    emblaApi.on('select', onSelect);
+    return () => {
+      emblaApi.off('select', onSelect);
+    };
+  }, [emblaApi, page, totalPage]);
 
   // 페이지 데이터를 10개씩 그룹화
   const groupedRanks = ranks.reduce((acc: RankType[][], rank, index) => {
@@ -45,46 +60,40 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
 
   return (
     <div className={rankingListStyle}>
-      <Flicking
-        className={flickingStyle}
-        defaultIndex={page - 1}
-        circular={false}
-        moveType="strict"
-        bound={true}
-        renderOnlyVisible={true}
-        onMoveEnd={handleMoveEnd}
-      >
-        {groupedRanks.map((group, index) => (
-          <div key={index} className={slideStyle}>
-            <table className={tableStyle}>
-              <thead>
-                <tr className={theadTrStyle}>
-                  <th>Rank</th>
-                  <th>Pet</th>
-                  <th>Name</th>
-                  <th>Contribution</th>
-                </tr>
-              </thead>
-              <tbody>
-                {group.map((item) => (
-                  <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
-                    <td>{item.rank}</td>
-                    <td>
-                      <RankingLink id={item.name}>
-                        <img src={item.image} alt={item.name} width={60} height={60} />
-                      </RankingLink>
-                    </td>
-                    <td>
-                      <RankingLink id={item.name}>{item.name}</RankingLink>
-                    </td>
-                    <td>{item.contributions}</td>
+      <div className={emblaViewportStyle} ref={emblaRef}>
+        <div className={emblaContainerStyle}>
+          {groupedRanks.map((group, index) => (
+            <div key={index} className={cx(slideStyle, emblaSlideStyle)}>
+              <table className={tableStyle}>
+                <thead>
+                  <tr className={theadTrStyle}>
+                    <th>Rank</th>
+                    <th>Pet</th>
+                    <th>Name</th>
+                    <th>Contribution</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ))}
-      </Flicking>
+                </thead>
+                <tbody>
+                  {group.map((item) => (
+                    <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
+                      <td>{item.rank}</td>
+                      <td>
+                        <RankingLink id={item.name}>
+                          <img src={item.image} alt={item.name} width={60} height={60} />
+                        </RankingLink>
+                      </td>
+                      <td>
+                        <RankingLink id={item.name}>{item.name}</RankingLink>
+                      </td>
+                      <td>{item.contributions}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </div>
+      </div>
       <div className={paginationStyle}>
         {[0, 1, 2].map((group, index) => {
           const isActive =
@@ -98,13 +107,13 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
   );
 }
 
-const flickingStyle = css({
+const emblaViewportStyle = css({
   width: '100%',
-  height: 'auto',
-  margin: '0 auto',
-  position: 'relative',
   overflow: 'hidden',
 });
+
+const emblaContainerStyle = css({ display: 'flex' });
+const emblaSlideStyle = css({ flex: '0 0 100%', minWidth: 0 });
 
 const slideStyle = css({
   width: '100%',

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -24,11 +24,9 @@ export function MobileRankingTable({ initialRanks, initialPage, totalPage, type 
   const { data: session } = useSession();
   const currentUsername = session?.user?.name;
   const [page, setPage] = useState(initialPage);
-  const [slideDirection, setSlideDirection] = useState<'left' | 'right' | null>(null);
   const touchStartX = useRef(0);
 
   const goToPage = (next: number) => {
-    setSlideDirection(next > page ? 'left' : 'right');
     setPage(next);
   };
 
@@ -68,8 +66,7 @@ export function MobileRankingTable({ initialRanks, initialPage, totalPage, type 
   return (
     <div className={containerStyle} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
       <div
-        key={page}
-        className={cx(tableWrapperStyle, isPlaceholderData && fetchingStyle, slideDirection === 'left' && slideInFromRight, slideDirection === 'right' && slideInFromLeft)}
+        className={cx(tableWrapperStyle, isPlaceholderData && fetchingStyle)}
       >
         <RankingTableView ranks={ranks} currentUsername={currentUsername} />
       </div>
@@ -150,14 +147,6 @@ const tableWrapperStyle = css({
 
 const fetchingStyle = css({
   opacity: 0.5,
-});
-
-const slideInFromRight = css({
-  animation: 'slideFromRight 0.2s ease-out',
-});
-
-const slideInFromLeft = css({
-  animation: 'slideFromLeft 0.2s ease-out',
 });
 
 const paginationStyle = css({

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -7,13 +7,23 @@ import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
 import useEmblaCarousel from 'embla-carousel-react';
 import type { RankType } from '@gitanimals/api';
+import { rankQueries } from '@gitanimals/react-query';
 import { getNewUrl } from '@gitanimals/util-common';
+import { useQuery } from '@tanstack/react-query';
 
 import { RankingLink } from './RankingLink';
 
+const RANKS_PER_PAGE = 5;
 const CURRENT_SLIDE_INDEX = 1;
 
-export function MobileRankingTable({ ranks, page, totalPage }: { page: number; ranks: RankType[]; totalPage: number }) {
+interface MobileRankingTableProps {
+  ranks: RankType[];
+  page: number;
+  totalPage: number;
+  type: 'WEEKLY_USER_CONTRIBUTIONS' | 'WEEKLY_GUILD_CONTRIBUTIONS';
+}
+
+export function MobileRankingTable({ ranks, page, totalPage, type }: MobileRankingTableProps) {
   const router = useRouter();
   const { data: session } = useSession();
   const searchParams = useSearchParams();
@@ -21,6 +31,19 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
 
   const hasPrev = page > 0;
   const hasNext = page < totalPage;
+
+  const prevRankStart = (page - 1) * RANKS_PER_PAGE + 4;
+  const nextRankStart = (page + 1) * RANKS_PER_PAGE + 4;
+
+  const { data: prevRanks } = useQuery({
+    ...rankQueries.getRanksOptions({ rank: prevRankStart, size: RANKS_PER_PAGE, type }),
+    enabled: hasPrev,
+  });
+
+  const { data: nextRanks } = useQuery({
+    ...rankQueries.getRanksOptions({ rank: nextRankStart, size: RANKS_PER_PAGE, type }),
+    enabled: hasNext,
+  });
 
   const [emblaRef, emblaApi] = useEmblaCarousel({ startIndex: CURRENT_SLIDE_INDEX });
 
@@ -53,7 +76,48 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
     };
   }, [emblaApi, page, totalPage]);
 
-  const renderTable = () => (
+  return (
+    <div className={rankingListStyle}>
+      <div className={emblaViewportStyle} ref={emblaRef}>
+        <div className={emblaContainerStyle}>
+          {hasPrev && (
+            <div className={emblaSlideStyle}>
+              <RankingTableView ranks={prevRanks} currentUsername={currentUsername} />
+            </div>
+          )}
+          <div className={emblaSlideStyle}>
+            <RankingTableView ranks={ranks} currentUsername={currentUsername} />
+          </div>
+          {hasNext && (
+            <div className={emblaSlideStyle}>
+              <RankingTableView ranks={nextRanks} currentUsername={currentUsername} />
+            </div>
+          )}
+        </div>
+      </div>
+      <div className={paginationStyle}>
+        {[0, 1, 2].map((_, index) => {
+          const isActive =
+            (page === 0 && index === 0) ||
+            (page !== 0 && page !== totalPage && index === 1) ||
+            (page === totalPage && index === 2);
+          return <div key={index} className={cx(paginationBulletStyle, isActive && 'active')}></div>;
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RankingTableView({
+  ranks,
+  currentUsername,
+}: {
+  ranks: RankType[] | undefined;
+  currentUsername: string | null | undefined;
+}) {
+  if (!ranks) return null;
+
+  return (
     <table className={tableStyle}>
       <thead>
         <tr className={theadTrStyle}>
@@ -80,27 +144,6 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
         ))}
       </tbody>
     </table>
-  );
-
-  return (
-    <div className={rankingListStyle}>
-      <div className={emblaViewportStyle} ref={emblaRef}>
-        <div className={emblaContainerStyle}>
-          {hasPrev && <div className={emblaSlideStyle} />}
-          <div className={emblaSlideStyle}>{renderTable()}</div>
-          {hasNext && <div className={emblaSlideStyle} />}
-        </div>
-      </div>
-      <div className={paginationStyle}>
-        {[0, 1, 2].map((_, index) => {
-          const isActive =
-            (page === 0 && index === 0) ||
-            (page !== 0 && page !== totalPage && index === 1) ||
-            (page === totalPage && index === 2);
-          return <div key={index} className={cx(paginationBulletStyle, isActive && 'active')}></div>;
-        })}
-      </div>
-    </div>
   );
 }
 

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -65,9 +65,15 @@ export function MobileRankingTable({ initialRanks, initialPage, totalPage, type 
         <RankingTableView ranks={ranks} currentUsername={currentUsername} />
       </div>
       <div className={paginationStyle}>
+        <button className={arrowButtonStyle} onClick={() => setPage((p) => p - 1)} disabled={page <= 0} aria-label="이전 페이지">
+          ‹
+        </button>
         <span className={paginationTextStyle}>
           {page + 1} / {totalPage + 1}
         </span>
+        <button className={arrowButtonStyle} onClick={() => setPage((p) => p + 1)} disabled={page >= totalPage} aria-label="다음 페이지">
+          ›
+        </button>
       </div>
     </div>
   );
@@ -147,6 +153,23 @@ const paginationStyle = css({
 const paginationTextStyle = css({
   textStyle: 'glyph14.regular',
   color: 'white.white_50',
+});
+
+const arrowButtonStyle = css({
+  width: '32px',
+  height: '32px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 'none',
+  background: 'none',
+  color: 'white.white_75',
+  fontSize: '20px',
+  cursor: 'pointer',
+  _disabled: {
+    opacity: 0.25,
+    cursor: 'default',
+  },
 });
 
 const tableStyle = css({

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
 import useEmblaCarousel from 'embla-carousel-react';
 import type { RankType } from '@gitanimals/api';
 import { rankQueries } from '@gitanimals/react-query';
-import { getNewUrl } from '@gitanimals/util-common';
 import { useQuery } from '@tanstack/react-query';
 
 import { RankingLink } from './RankingLink';
@@ -23,17 +20,23 @@ interface MobileRankingTableProps {
   type: 'WEEKLY_USER_CONTRIBUTIONS' | 'WEEKLY_GUILD_CONTRIBUTIONS';
 }
 
-export function MobileRankingTable({ ranks, page, totalPage, type }: MobileRankingTableProps) {
-  const router = useRouter();
+export function MobileRankingTable({ ranks: initialRanks, page: initialPage, totalPage, type }: MobileRankingTableProps) {
   const { data: session } = useSession();
-  const searchParams = useSearchParams();
   const currentUsername = session?.user?.name;
+
+  const [page, setPage] = useState(initialPage);
 
   const hasPrev = page > 0;
   const hasNext = page < totalPage;
 
+  const currentRankStart = page * RANKS_PER_PAGE + 4;
   const prevRankStart = (page - 1) * RANKS_PER_PAGE + 4;
   const nextRankStart = (page + 1) * RANKS_PER_PAGE + 4;
+
+  const { data: currentRanks } = useQuery({
+    ...rankQueries.getRanksOptions({ rank: currentRankStart, size: RANKS_PER_PAGE, type }),
+    initialData: page === initialPage ? initialRanks : undefined,
+  });
 
   const { data: prevRanks } = useQuery({
     ...rankQueries.getRanksOptions({ rank: prevRankStart, size: RANKS_PER_PAGE, type }),
@@ -46,11 +49,6 @@ export function MobileRankingTable({ ranks, page, totalPage, type }: MobileRanki
   });
 
   const [emblaRef, emblaApi] = useEmblaCarousel({ startIndex: CURRENT_SLIDE_INDEX });
-
-  const getRankingPageUrl = (params: Record<string, unknown>) => {
-    const oldParams = Object.fromEntries(searchParams.entries());
-    return getNewUrl({ baseUrl: '/', newParams: params, oldParams });
-  };
 
   useEffect(() => {
     if (!emblaApi) return;
@@ -66,8 +64,7 @@ export function MobileRankingTable({ ranks, page, totalPage, type }: MobileRanki
         return;
       }
 
-      const newUrl = getRankingPageUrl({ page: newPage });
-      router.push(newUrl);
+      setPage(newPage);
     };
 
     emblaApi.on('settle', onSettle);
@@ -86,7 +83,7 @@ export function MobileRankingTable({ ranks, page, totalPage, type }: MobileRanki
             </div>
           )}
           <div className={emblaSlideStyle}>
-            <RankingTableView ranks={ranks} currentUsername={currentUsername} />
+            <RankingTableView ranks={currentRanks} currentUsername={currentUsername} />
           </div>
           {hasNext && (
             <div className={emblaSlideStyle}>

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -78,7 +78,7 @@ export function MobileRankingTable({ ranks, page, totalPage, type }: MobileRanki
 
   return (
     <div className={rankingListStyle}>
-      <div className={emblaViewportStyle} ref={emblaRef}>
+      <div key={page} className={emblaViewportStyle} ref={emblaRef}>
         <div className={emblaContainerStyle}>
           {hasPrev && (
             <div className={emblaSlideStyle}>

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -17,19 +17,19 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
   const { data: session } = useSession();
   const searchParams = useSearchParams();
   const currentUsername = session?.user?.name;
-  const touchStartXRef = useRef(0);
+  const pointerStartXRef = useRef(0);
 
   const getRankingPageUrl = (params: Record<string, unknown>) => {
     const oldParams = Object.fromEntries(searchParams.entries());
     return getNewUrl({ baseUrl: '/', newParams: params, oldParams });
   };
 
-  const handleTouchStart = (e: React.TouchEvent) => {
-    touchStartXRef.current = e.touches[0].clientX;
+  const handlePointerDown = (e: React.PointerEvent) => {
+    pointerStartXRef.current = e.clientX;
   };
 
-  const handleTouchEnd = (e: React.TouchEvent) => {
-    const diff = touchStartXRef.current - e.changedTouches[0].clientX;
+  const handlePointerUp = (e: React.PointerEvent) => {
+    const diff = pointerStartXRef.current - e.clientX;
     if (Math.abs(diff) < SWIPE_THRESHOLD) return;
 
     // 원래 Flicking 매핑 유지: swipe left(NEXT) → page - 1, swipe right(PREV) → page + 1
@@ -43,7 +43,7 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
   };
 
   return (
-    <div className={rankingListStyle} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+    <div className={rankingListStyle} onPointerDown={handlePointerDown} onPointerUp={handlePointerUp}>
       <table className={tableStyle}>
         <thead>
           <tr className={theadTrStyle}>
@@ -71,7 +71,7 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
         </tbody>
       </table>
       <div className={paginationStyle}>
-        {[0, 1, 2].map((group, index) => {
+        {[0, 1, 2].map((_, index) => {
           const isActive =
             (page === 0 && index === 0) ||
             (page !== 0 && page !== totalPage && index === 1) ||

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -1,99 +1,75 @@
-import { useEffect, useRef } from 'react';
+'use client';
+
+import { useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
-import useEmblaCarousel from 'embla-carousel-react';
 import type { RankType } from '@gitanimals/api';
 import { getNewUrl } from '@gitanimals/util-common';
 
 import { RankingLink } from './RankingLink';
+
+const SWIPE_THRESHOLD = 50;
 
 export function MobileRankingTable({ ranks, page, totalPage }: { page: number; ranks: RankType[]; totalPage: number }) {
   const router = useRouter();
   const { data: session } = useSession();
   const searchParams = useSearchParams();
   const currentUsername = session?.user?.name;
-  const prevIndexRef = useRef(page - 1);
-
-  const [emblaRef, emblaApi] = useEmblaCarousel({ startIndex: page - 1 });
+  const touchStartXRef = useRef(0);
 
   const getRankingPageUrl = (params: Record<string, unknown>) => {
     const oldParams = Object.fromEntries(searchParams.entries());
     return getNewUrl({ baseUrl: '/', newParams: params, oldParams });
   };
 
-  useEffect(() => {
-    if (!emblaApi) return;
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartXRef.current = e.touches[0].clientX;
+  };
 
-    const onSelect = () => {
-      const currentIndex = emblaApi.selectedScrollSnap();
-      const previousIndex = prevIndexRef.current;
-      if (currentIndex === previousIndex) return;
-      prevIndexRef.current = currentIndex;
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    const diff = touchStartXRef.current - e.changedTouches[0].clientX;
+    if (Math.abs(diff) < SWIPE_THRESHOLD) return;
 
-      // Flicking NEXT(index 증가) → page - 1, PREV(index 감소) → page + 1
-      const newPage = currentIndex > previousIndex ? page - 1 : page + 1;
+    // 원래 Flicking 매핑 유지: swipe left(NEXT) → page - 1, swipe right(PREV) → page + 1
+    const newPage = diff > 0 ? page - 1 : page + 1;
 
-      if (newPage < 0) return;
-      if (newPage > totalPage) return;
+    if (newPage < 0) return;
+    if (newPage > totalPage) return;
 
-      const newUrl = getRankingPageUrl({ page: newPage });
-      router.push(newUrl);
-    };
-
-    emblaApi.on('select', onSelect);
-    return () => {
-      emblaApi.off('select', onSelect);
-    };
-  }, [emblaApi, page, totalPage]);
-
-  // 페이지 데이터를 10개씩 그룹화
-  const groupedRanks = ranks.reduce((acc: RankType[][], rank, index) => {
-    const groupIndex = Math.floor(index / 10);
-    if (!acc[groupIndex]) {
-      acc[groupIndex] = [];
-    }
-    acc[groupIndex].push(rank);
-    return acc;
-  }, []);
+    const newUrl = getRankingPageUrl({ page: newPage });
+    router.push(newUrl);
+  };
 
   return (
-    <div className={rankingListStyle}>
-      <div className={emblaViewportStyle} ref={emblaRef}>
-        <div className={emblaContainerStyle}>
-          {groupedRanks.map((group, index) => (
-            <div key={index} className={cx(slideStyle, emblaSlideStyle)}>
-              <table className={tableStyle}>
-                <thead>
-                  <tr className={theadTrStyle}>
-                    <th>Rank</th>
-                    <th>Pet</th>
-                    <th>Name</th>
-                    <th>Contribution</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {group.map((item) => (
-                    <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
-                      <td>{item.rank}</td>
-                      <td>
-                        <RankingLink id={item.name}>
-                          <img src={item.image} alt={item.name} width={60} height={60} />
-                        </RankingLink>
-                      </td>
-                      <td>
-                        <RankingLink id={item.name}>{item.name}</RankingLink>
-                      </td>
-                      <td>{item.contributions}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+    <div className={rankingListStyle} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+      <table className={tableStyle}>
+        <thead>
+          <tr className={theadTrStyle}>
+            <th>Rank</th>
+            <th>Pet</th>
+            <th>Name</th>
+            <th>Contribution</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ranks.map((item) => (
+            <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
+              <td>{item.rank}</td>
+              <td>
+                <RankingLink id={item.name}>
+                  <img src={item.image} alt={item.name} width={60} height={60} />
+                </RankingLink>
+              </td>
+              <td>
+                <RankingLink id={item.name}>{item.name}</RankingLink>
+              </td>
+              <td>{item.contributions}</td>
+            </tr>
           ))}
-        </div>
-      </div>
+        </tbody>
+      </table>
       <div className={paginationStyle}>
         {[0, 1, 2].map((group, index) => {
           const isActive =
@@ -106,22 +82,6 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
     </div>
   );
 }
-
-const emblaViewportStyle = css({
-  width: '100%',
-  overflow: 'hidden',
-});
-
-const emblaContainerStyle = css({ display: 'flex' });
-const emblaSlideStyle = css({ flex: '0 0 100%', minWidth: 0 });
-
-const slideStyle = css({
-  width: '100%',
-  height: 'auto',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-});
 
 const paginationStyle = css({
   marginTop: '20px',

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -1,75 +1,96 @@
 'use client';
 
-import { useRef } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
+import useEmblaCarousel from 'embla-carousel-react';
 import type { RankType } from '@gitanimals/api';
 import { getNewUrl } from '@gitanimals/util-common';
 
 import { RankingLink } from './RankingLink';
 
-const SWIPE_THRESHOLD = 50;
+const CURRENT_SLIDE_INDEX = 1;
 
 export function MobileRankingTable({ ranks, page, totalPage }: { page: number; ranks: RankType[]; totalPage: number }) {
   const router = useRouter();
   const { data: session } = useSession();
   const searchParams = useSearchParams();
   const currentUsername = session?.user?.name;
-  const pointerStartXRef = useRef(0);
+
+  const hasPrev = page > 0;
+  const hasNext = page < totalPage;
+
+  const [emblaRef, emblaApi] = useEmblaCarousel({ startIndex: CURRENT_SLIDE_INDEX });
 
   const getRankingPageUrl = (params: Record<string, unknown>) => {
     const oldParams = Object.fromEntries(searchParams.entries());
     return getNewUrl({ baseUrl: '/', newParams: params, oldParams });
   };
 
-  const handlePointerDown = (e: React.PointerEvent) => {
-    pointerStartXRef.current = e.clientX;
-  };
+  useEffect(() => {
+    if (!emblaApi) return;
 
-  const handlePointerUp = (e: React.PointerEvent) => {
-    const diff = pointerStartXRef.current - e.clientX;
-    if (Math.abs(diff) < SWIPE_THRESHOLD) return;
+    const onSettle = () => {
+      const selectedIndex = emblaApi.selectedScrollSnap();
+      if (selectedIndex === CURRENT_SLIDE_INDEX) return;
 
-    // 원래 Flicking 매핑 유지: swipe left(NEXT) → page - 1, swipe right(PREV) → page + 1
-    const newPage = diff > 0 ? page - 1 : page + 1;
+      const newPage = selectedIndex < CURRENT_SLIDE_INDEX ? page + 1 : page - 1;
 
-    if (newPage < 0) return;
-    if (newPage > totalPage) return;
+      if (newPage < 0 || newPage > totalPage) {
+        emblaApi.scrollTo(CURRENT_SLIDE_INDEX, true);
+        return;
+      }
 
-    const newUrl = getRankingPageUrl({ page: newPage });
-    router.push(newUrl);
-  };
+      const newUrl = getRankingPageUrl({ page: newPage });
+      router.push(newUrl);
+    };
+
+    emblaApi.on('settle', onSettle);
+    return () => {
+      emblaApi.off('settle', onSettle);
+    };
+  }, [emblaApi, page, totalPage]);
+
+  const renderTable = () => (
+    <table className={tableStyle}>
+      <thead>
+        <tr className={theadTrStyle}>
+          <th>Rank</th>
+          <th>Pet</th>
+          <th>Name</th>
+          <th>Contribution</th>
+        </tr>
+      </thead>
+      <tbody>
+        {ranks.map((item) => (
+          <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
+            <td>{item.rank}</td>
+            <td>
+              <RankingLink id={item.name}>
+                <img src={item.image} alt={item.name} width={60} height={60} />
+              </RankingLink>
+            </td>
+            <td>
+              <RankingLink id={item.name}>{item.name}</RankingLink>
+            </td>
+            <td>{item.contributions}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
 
   return (
-    <div className={rankingListStyle} onPointerDown={handlePointerDown} onPointerUp={handlePointerUp}>
-      <table className={tableStyle}>
-        <thead>
-          <tr className={theadTrStyle}>
-            <th>Rank</th>
-            <th>Pet</th>
-            <th>Name</th>
-            <th>Contribution</th>
-          </tr>
-        </thead>
-        <tbody>
-          {ranks.map((item) => (
-            <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
-              <td>{item.rank}</td>
-              <td>
-                <RankingLink id={item.name}>
-                  <img src={item.image} alt={item.name} width={60} height={60} />
-                </RankingLink>
-              </td>
-              <td>
-                <RankingLink id={item.name}>{item.name}</RankingLink>
-              </td>
-              <td>{item.contributions}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className={rankingListStyle}>
+      <div className={emblaViewportStyle} ref={emblaRef}>
+        <div className={emblaContainerStyle}>
+          {hasPrev && <div className={emblaSlideStyle} />}
+          <div className={emblaSlideStyle}>{renderTable()}</div>
+          {hasNext && <div className={emblaSlideStyle} />}
+        </div>
+      </div>
       <div className={paginationStyle}>
         {[0, 1, 2].map((_, index) => {
           const isActive =
@@ -82,6 +103,10 @@ export function MobileRankingTable({ ranks, page, totalPage }: { page: number; r
     </div>
   );
 }
+
+const emblaViewportStyle = css({ overflow: 'hidden', width: '100%' });
+const emblaContainerStyle = css({ display: 'flex' });
+const emblaSlideStyle = css({ flex: '0 0 100%', minWidth: 0 });
 
 const paginationStyle = css({
   marginTop: '20px',

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -8,6 +8,8 @@ import type { RankType } from '@gitanimals/api';
 import { rankQueries } from '@gitanimals/react-query';
 import { useQuery } from '@tanstack/react-query';
 
+import { Skeleton } from '@gitanimals/ui-panda';
+
 import { RankingLink } from './RankingLink';
 
 const RANKS_PER_PAGE = 5;
@@ -112,8 +114,6 @@ function RankingTableView({
   ranks: RankType[] | undefined;
   currentUsername: string | null | undefined;
 }) {
-  if (!ranks) return null;
-
   return (
     <table className={tableStyle}>
       <thead>
@@ -125,20 +125,37 @@ function RankingTableView({
         </tr>
       </thead>
       <tbody>
-        {ranks.map((item) => (
-          <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
-            <td>{item.rank}</td>
-            <td>
-              <RankingLink id={item.name}>
-                <img src={item.image} alt={item.name} width={60} height={60} />
-              </RankingLink>
-            </td>
-            <td>
-              <RankingLink id={item.name}>{item.name}</RankingLink>
-            </td>
-            <td>{item.contributions}</td>
-          </tr>
-        ))}
+        {ranks
+          ? ranks.map((item) => (
+              <tr key={item.rank} className={cx(trStyle, item.name === currentUsername && currentUserTrStyle)}>
+                <td>{item.rank}</td>
+                <td>
+                  <RankingLink id={item.name}>
+                    <img src={item.image} alt={item.name} width={60} height={60} />
+                  </RankingLink>
+                </td>
+                <td>
+                  <RankingLink id={item.name}>{item.name}</RankingLink>
+                </td>
+                <td>{item.contributions}</td>
+              </tr>
+            ))
+          : Array.from({ length: RANKS_PER_PAGE }).map((_, i) => (
+              <tr key={i} className={trStyle}>
+                <td>
+                  <Skeleton style={{ width: 20, height: 20, borderRadius: 4 }} />
+                </td>
+                <td>
+                  <Skeleton style={{ width: 40, height: 40, borderRadius: '50%' }} />
+                </td>
+                <td>
+                  <Skeleton style={{ width: 80, height: 16, borderRadius: 4 }} />
+                </td>
+                <td>
+                  <Skeleton style={{ width: 40, height: 16, borderRadius: 4 }} />
+                </td>
+              </tr>
+            ))}
       </tbody>
     </table>
   );

--- a/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/MobileRankingTable.tsx
@@ -1,107 +1,73 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { css, cx } from '_panda/css';
-import useEmblaCarousel from 'embla-carousel-react';
 import type { RankType } from '@gitanimals/api';
 import { rankQueries } from '@gitanimals/react-query';
-import { useQuery } from '@tanstack/react-query';
-
 import { Skeleton } from '@gitanimals/ui-panda';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { RankingLink } from './RankingLink';
 
 const RANKS_PER_PAGE = 5;
-const CURRENT_SLIDE_INDEX = 1;
+const SWIPE_THRESHOLD = 50;
 
 interface MobileRankingTableProps {
-  ranks: RankType[];
-  page: number;
+  initialRanks: RankType[];
+  initialPage: number;
   totalPage: number;
   type: 'WEEKLY_USER_CONTRIBUTIONS' | 'WEEKLY_GUILD_CONTRIBUTIONS';
 }
 
-export function MobileRankingTable({ ranks: initialRanks, page: initialPage, totalPage, type }: MobileRankingTableProps) {
+export function MobileRankingTable({ initialRanks, initialPage, totalPage, type }: MobileRankingTableProps) {
   const { data: session } = useSession();
   const currentUsername = session?.user?.name;
-
   const [page, setPage] = useState(initialPage);
+  const touchStartX = useRef(0);
 
-  const hasPrev = page > 0;
-  const hasNext = page < totalPage;
+  const rankStart = page * RANKS_PER_PAGE + 4;
 
-  const currentRankStart = page * RANKS_PER_PAGE + 4;
-  const prevRankStart = (page - 1) * RANKS_PER_PAGE + 4;
-  const nextRankStart = (page + 1) * RANKS_PER_PAGE + 4;
-
-  const { data: currentRanks } = useQuery({
-    ...rankQueries.getRanksOptions({ rank: currentRankStart, size: RANKS_PER_PAGE, type }),
+  const { data: ranks, isPlaceholderData } = useQuery({
+    ...rankQueries.getRanksOptions({ rank: rankStart, size: RANKS_PER_PAGE, type }),
     initialData: page === initialPage ? initialRanks : undefined,
+    placeholderData: keepPreviousData,
   });
 
-  const { data: prevRanks } = useQuery({
-    ...rankQueries.getRanksOptions({ rank: prevRankStart, size: RANKS_PER_PAGE, type }),
-    enabled: hasPrev,
+  // Prefetch adjacent pages
+  useQuery({
+    ...rankQueries.getRanksOptions({ rank: (page - 1) * RANKS_PER_PAGE + 4, size: RANKS_PER_PAGE, type }),
+    enabled: page > 0,
+  });
+  useQuery({
+    ...rankQueries.getRanksOptions({ rank: (page + 1) * RANKS_PER_PAGE + 4, size: RANKS_PER_PAGE, type }),
+    enabled: page < totalPage,
   });
 
-  const { data: nextRanks } = useQuery({
-    ...rankQueries.getRanksOptions({ rank: nextRankStart, size: RANKS_PER_PAGE, type }),
-    enabled: hasNext,
-  });
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
 
-  const [emblaRef, emblaApi] = useEmblaCarousel({ startIndex: CURRENT_SLIDE_INDEX });
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    const diff = touchStartX.current - e.changedTouches[0].clientX;
+    if (Math.abs(diff) < SWIPE_THRESHOLD) return;
 
-  useEffect(() => {
-    if (!emblaApi) return;
-
-    const onSettle = () => {
-      const selectedIndex = emblaApi.selectedScrollSnap();
-      if (selectedIndex === CURRENT_SLIDE_INDEX) return;
-
-      const newPage = selectedIndex < CURRENT_SLIDE_INDEX ? page + 1 : page - 1;
-
-      if (newPage < 0 || newPage > totalPage) {
-        emblaApi.scrollTo(CURRENT_SLIDE_INDEX, true);
-        return;
-      }
-
-      setPage(newPage);
-    };
-
-    emblaApi.on('settle', onSettle);
-    return () => {
-      emblaApi.off('settle', onSettle);
-    };
-  }, [emblaApi, page, totalPage]);
+    if (diff > 0 && page < totalPage) {
+      setPage((p) => p + 1);
+    } else if (diff < 0 && page > 0) {
+      setPage((p) => p - 1);
+    }
+  };
 
   return (
-    <div className={rankingListStyle}>
-      <div key={page} className={emblaViewportStyle} ref={emblaRef}>
-        <div className={emblaContainerStyle}>
-          {hasPrev && (
-            <div className={emblaSlideStyle}>
-              <RankingTableView ranks={prevRanks} currentUsername={currentUsername} />
-            </div>
-          )}
-          <div className={emblaSlideStyle}>
-            <RankingTableView ranks={currentRanks} currentUsername={currentUsername} />
-          </div>
-          {hasNext && (
-            <div className={emblaSlideStyle}>
-              <RankingTableView ranks={nextRanks} currentUsername={currentUsername} />
-            </div>
-          )}
-        </div>
+    <div className={containerStyle} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+      <div className={cx(tableWrapperStyle, isPlaceholderData && fetchingStyle)}>
+        <RankingTableView ranks={ranks} currentUsername={currentUsername} />
       </div>
       <div className={paginationStyle}>
-        {[0, 1, 2].map((_, index) => {
-          const isActive =
-            (page === 0 && index === 0) ||
-            (page !== 0 && page !== totalPage && index === 1) ||
-            (page === totalPage && index === 2);
-          return <div key={index} className={cx(paginationBulletStyle, isActive && 'active')}></div>;
-        })}
+        <span className={paginationTextStyle}>
+          {page + 1} / {totalPage + 1}
+        </span>
       </div>
     </div>
   );
@@ -161,34 +127,26 @@ function RankingTableView({
   );
 }
 
-const emblaViewportStyle = css({ overflow: 'hidden', width: '100%' });
-const emblaContainerStyle = css({ display: 'flex' });
-const emblaSlideStyle = css({ flex: '0 0 100%', minWidth: 0 });
+const containerStyle = css({ width: '100%' });
+
+const tableWrapperStyle = css({
+  transition: 'opacity 0.15s ease',
+});
+
+const fetchingStyle = css({
+  opacity: 0.5,
+});
 
 const paginationStyle = css({
-  marginTop: '20px',
-  position: 'relative',
-  height: '30px',
+  marginTop: '16px',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: 2,
 });
 
-const paginationBulletStyle = css({
-  width: '8px',
-  height: '8px',
-  borderRadius: '50%',
-  backgroundColor: 'white.white_50',
-  cursor: 'pointer',
-
-  '&.active': {
-    backgroundColor: 'white.white_100',
-  },
-});
-
-const rankingListStyle = css({
-  width: '100%',
+const paginationTextStyle = css({
+  textStyle: 'glyph14.regular',
+  color: 'white.white_50',
 });
 
 const tableStyle = css({
@@ -199,7 +157,7 @@ const tableStyle = css({
 });
 
 const trBaseStyle = css({
-  borderRadius: '8px',
+  borderRadius: '6px',
 
   '& img': {
     borderRadius: '50%',
@@ -208,43 +166,23 @@ const trBaseStyle = css({
 
   '& td, & th': {
     border: 'none',
-    padding: '0 16px',
+    padding: '0 8px',
   },
 
   '& td:first-child, & th:first-child': {
-    paddingLeft: '40px',
-    borderRadius: '8px 0 0 8px',
-    width: '120px',
+    paddingLeft: '16px',
+    borderRadius: '6px 0 0 6px',
+    width: '54px',
   },
   '& td:last-child, & th:last-child': {
-    paddingRight: '40px',
-    borderRadius: '0 8px 8px 0',
+    paddingRight: '16px',
+    borderRadius: '0 6px 6px 0',
     textAlign: 'right',
   },
   '& td:nth-child(2), & th:nth-child(2)': {
     textAlign: 'center',
-    width: '72px',
-    padding: '0 8px',
-  },
-
-  _mobile: {
-    borderRadius: '6px',
-    '& td, & th': {
-      border: 'none',
-      padding: '0 8px',
-    },
-
-    '& td:first-child, & th:first-child': {
-      paddingLeft: '16px',
-      width: '54px',
-    },
-    '& td:last-child, & th:last-child': {
-      paddingRight: '16px',
-    },
-    '& td:nth-child(2), & th:nth-child(2)': {
-      width: '28px',
-      paddingLeft: '0px',
-    },
+    width: '28px',
+    paddingLeft: '0px',
   },
 });
 
@@ -264,21 +202,14 @@ const trStyle = cx(
     textStyle: 'glyph18.regular',
     color: 'white.white_100',
     backgroundColor: 'white.white_10',
-    height: '60px',
+    height: '48px',
+    fontSize: 'glyph15.regular',
 
     '& td:first-child': {
-      fontSize: '20px',
+      fontSize: '16px',
       lineHeight: '28px',
       fontFamily: 'token(fonts.dnf)',
       color: 'white.white_50',
-    },
-    _mobile: {
-      height: '48px',
-      fontSize: 'glyph15.regular',
-
-      '& td:first-child': {
-        fontSize: '16px',
-      },
     },
   }),
 );

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
@@ -58,7 +58,7 @@ export default function RankingSection({
           <div className={screenContentStyle}>
             <RankingTab selectedTab={selectedTab} />
             <TopPodium ranks={queries[0].data} />
-            <MobileRankingTable ranks={queries[1].data} page={currentPage} totalPage={totalPage} type={type} />
+            <MobileRankingTable initialRanks={queries[1].data} initialPage={currentPage} totalPage={totalPage} type={type} />
             <MobileGameConsole />
           </div>
         }

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
@@ -58,7 +58,12 @@ export default function RankingSection({
           <div className={screenContentStyle}>
             <RankingTab selectedTab={selectedTab} />
             <TopPodium ranks={queries[0].data} />
-            <MobileRankingTable initialRanks={queries[1].data} initialPage={currentPage} totalPage={totalPage} type={type} />
+            <MobileRankingTable
+              initialRanks={queries[1].data}
+              initialPage={currentPage}
+              totalPage={totalPage}
+              type={type}
+            />
             <MobileGameConsole />
           </div>
         }

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingSection.tsx
@@ -58,7 +58,7 @@ export default function RankingSection({
           <div className={screenContentStyle}>
             <RankingTab selectedTab={selectedTab} />
             <TopPodium ranks={queries[0].data} />
-            <MobileRankingTable ranks={queries[1].data} page={currentPage} totalPage={totalPage} />
+            <MobileRankingTable ranks={queries[1].data} page={currentPage} totalPage={totalPage} type={type} />
             <MobileGameConsole />
           </div>
         }

--- a/apps/web/src/app/[locale]/landing/RankingSection/RankingServerSide.tsx
+++ b/apps/web/src/app/[locale]/landing/RankingSection/RankingServerSide.tsx
@@ -11,11 +11,12 @@ const RANKS_TOP_3 = 3 as const;
 const RANKS_PER_PAGE = TOTAL_VIEW_RANKS - RANKS_TOP_3;
 
 export async function RankingServerSide({
-  searchParams,
+  searchParams: searchParamsPromise,
 }: {
-  searchParams: { [key: string]: string | string[] | undefined };
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   try {
+    const searchParams = await searchParamsPromise;
     const type = searchParams.ranking ?? 'people';
 
     const session = await getServerSession();

--- a/apps/web/src/app/[locale]/landing/index.ts
+++ b/apps/web/src/app/[locale]/landing/index.ts
@@ -1,5 +1,8 @@
 import { AvailablePetSection } from './AvailablePetSection';
+import { ChoosePetSection } from './ChoosePetSection';
+import { Footer } from './Footer';
 import { HavePetWaySection } from './HavePetWaySection';
 import { MainSection } from './MainSection';
+import { RankingServerSide } from './RankingSection/RankingServerSide';
 
-export { AvailablePetSection, HavePetWaySection, MainSection };
+export { AvailablePetSection, ChoosePetSection, Footer, HavePetWaySection, MainSection, RankingServerSide };

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,15 +1,18 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { css } from '_panda/css';
 import { ErrorBoundary } from '@suspensive/react';
 
 import { ErrorSection } from '@/components/Error/ErrorSection';
 import GNB from '@/components/GNB/GNB';
 
-import { ChoosePetSection } from './landing/ChoosePetSection';
-import { Footer } from './landing/Footer';
-import { RankingServerSide } from './landing/RankingSection/RankingServerSide';
-import { AvailablePetSection, HavePetWaySection, MainSection } from './landing';
+import {
+  AvailablePetSection,
+  ChoosePetSection,
+  Footer,
+  HavePetWaySection,
+  MainSection,
+  RankingServerSide,
+} from './landing';
 
 import '@egjs/react-flicking/dist/flicking.css';
 import '@egjs/react-flicking/dist/flicking-inline.css';
@@ -22,22 +25,28 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function HomePage({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const t = await getTranslations('Error');
+
   return (
-    <div>
+    <>
       <GNB />
-      <MainSection />
-      <ErrorBoundary
-        fallback={<ErrorSection title="랭킹 정보를 불러올 수 없습니다" description="잠시 후 다시 시도해주세요" />}
-      >
-        <RankingServerSide searchParams={searchParams} />
-      </ErrorBoundary>
-      <AvailablePetSection />
-      <HavePetWaySection />
-      <ChoosePetSection />
-      <div className={css({ bg: 'black' })}>
-        <Footer />
-      </div>
-    </div>
+      <main>
+        <MainSection />
+        <ErrorBoundary
+          fallback={<ErrorSection title={t('ranking-error-title')} description={t('ranking-error-description')} />}
+        >
+          <RankingServerSide searchParams={searchParams} />
+        </ErrorBoundary>
+        <AvailablePetSection />
+        <HavePetWaySection />
+        <ChoosePetSection />
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/apps/web/src/components/Responsive/Responsive.tsx
+++ b/apps/web/src/components/Responsive/Responsive.tsx
@@ -1,0 +1,33 @@
+import type { ComponentProps, ElementType } from 'react';
+import { css, cx } from '_panda/css';
+
+const desktopClass = css({ display: 'block', _mobile: { display: 'none' } });
+const mobileClass = css({ display: 'none', _mobile: { display: 'block' } });
+
+type ResponsiveProps<C extends ElementType> = {
+  component: C;
+  desktop?: Partial<ComponentProps<C>>;
+  mobile?: Partial<ComponentProps<C>>;
+} & Omit<ComponentProps<C>, 'component' | 'desktop' | 'mobile'>;
+
+export function Responsive<C extends ElementType>({
+  component: Component,
+  desktop,
+  mobile,
+  children,
+  ...sharedProps
+}: ResponsiveProps<C>) {
+  const Comp = Component as ElementType;
+  const shared = sharedProps as Record<string, unknown>;
+
+  return (
+    <>
+      <Comp {...shared} {...desktop} className={cx(desktopClass, shared.className as string, desktop?.className)}>
+        {children}
+      </Comp>
+      <Comp {...shared} {...mobile} className={cx(mobileClass, shared.className as string, mobile?.className)}>
+        {children}
+      </Comp>
+    </>
+  );
+}

--- a/apps/web/src/components/Responsive/index.ts
+++ b/apps/web/src/components/Responsive/index.ts
@@ -1,0 +1,1 @@
+export { Responsive } from './Responsive';

--- a/packages/ui/panda/src/theme/keyframes.ts
+++ b/packages/ui/panda/src/theme/keyframes.ts
@@ -72,6 +72,22 @@ export const keyframes = defineKeyframes({
       transform: 'translate3d(-100%, 0, 0)',
     },
   },
+  slideFromRight: {
+    from: {
+      transform: 'translateX(30%)',
+    },
+    to: {
+      transform: 'translateX(0)',
+    },
+  },
+  slideFromLeft: {
+    from: {
+      transform: 'translateX(-30%)',
+    },
+    to: {
+      transform: 'translateX(0)',
+    },
+  },
   skeletonLoading: {
     '0%': {
       backgroundPosition: '200% 0',


### PR DESCRIPTION
## 💻 작업 내용

랜딩 페이지 전반의 구조 개선과 MobileRankingTable의 UX를 대폭 개선한 PR입니다.

### 랜딩 페이지 구조 개선
- `searchParams`를 Promise 타입으로 수정 (Next.js 14 App Router 호환)
- barrel export 통일 (`landing/index.ts`에서 모든 섹션 export)
- 시멘틱 HTML 적용 (`<main>`, Fragment 구조)
- ErrorBoundary 에러 메시지 i18n 적용
- Footer 배경색을 컴포넌트 내부 스타일로 이동, 래퍼 div 제거

### Responsive 제네릭 래퍼 컴포넌트 도입
- 데스크탑/모바일 컴포넌트를 2개씩 렌더링하고 CSS로 숨기는 패턴을 타입 안전한 제네릭 `Responsive` 컴포넌트로 통합
- MainSection, ChoosePetSection, AvailablePetSection 3곳 적용

### @egjs/react-flicking → 터치 스와이프 마이그레이션
- **MainSlider**: `@egjs/react-flicking` → `embla-carousel-react` 마이그레이션
- **MobileRankingTable**: `@egjs/react-flicking` → embla 시도 후, 최종적으로 embla도 제거하고 **순수 터치 스와이프**로 재작성
  - embla의 startIndex/방향 버그, 연속 스와이프 이슈 등을 거쳐 근본적으로 해결

### MobileRankingTable UX 개선 (핵심 변경)
- **이전**: `router.push`로 URL 기반 페이지 전환 → 스크롤 상단 이동 문제, flicking 라이브러리 의존
- **이후**: `useState`로 클라이언트 상태 페이지 관리 + 터치 스와이프 + `keepPreviousData`
  - 페이지 전환 시 스크롤 위치 유지
  - 터치 스와이프로 직관적 페이지 이동 (threshold: 50px)
  - `keepPreviousData`로 데이터 로딩 중 이전 데이터 유지 + opacity 피드백
  - 인접 페이지 prefetch로 빠른 전환
  - 로딩 스켈레톤 추가
  - 화살표 버튼(‹ ›) 추가 (첫/마지막 페이지 비활성화)
  - 방향에 맞는 슬라이드 애니메이션 (slideFromLeft/slideFromRight keyframes)

## 📸 스크린샷

MobileRankingTable에 터치 스와이프, 화살표 버튼, 슬라이드 애니메이션, 로딩 스켈레톤이 추가되었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 주요 변경 사항

* **새로운 기능**
  * 반응형 컴포넌트 적용으로 랜딩 페이지의 버튼이 기기별에 맞춰 자동 크기 조정
  * 모바일 랭킹에서 클라이언트 사이드 페이징 및 스와이프 네비게이션 도입

* **개선 사항**
  * 캐러셀 구현 변경으로 슬라이드 탐색 및 성능 개선
  * 푸터 배경 복구 및 전반적 레이아웃·스타일 정제
  * 랭킹 로딩 실패 시 사용자용 오류 문구 번역 적용

* **버그 수정**
  * 랭킹 관련 오류 안내 문구 추가로 실패 상황 안내 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->