### PR TITLE
feat: dev → main Release PR 자동 생성 워크플로우 추가

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,129 @@
+name: Release PR
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes
+        id: check
+        run: |
+          COMMIT_COUNT=$(git rev-list --count origin/main..origin/dev 2>/dev/null || echo "0")
+          echo "commit_count=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COMMIT_COUNT" -eq 0 ]; then
+            echo "No commits between main and dev. Skipping."
+          fi
+
+      - name: Parse commits and generate body
+        if: steps.check.outputs.commit_count != '0'
+        id: generate
+        run: |
+          COMMITS=$(git log origin/main..origin/dev --no-merges --format="%s")
+
+          FEAT=""
+          FIX=""
+          REFACTOR=""
+          STYLE=""
+          DOCS=""
+          CHORE=""
+
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+
+            # prefix 제거하여 메시지 추출
+            msg=$(echo "$line" | sed 's/^[a-z]*\(([^)]*)\)\?[!]\?: *//')
+
+            case "$line" in
+              feat:*|feat\(*)       FEAT="${FEAT}- ${msg}"$'\n' ;;
+              fix:*|fix\(*)         FIX="${FIX}- ${msg}"$'\n' ;;
+              refactor:*|refactor\(*) REFACTOR="${REFACTOR}- ${msg}"$'\n' ;;
+              style:*|style\(*)     STYLE="${STYLE}- ${msg}"$'\n' ;;
+              docs:*|docs\(*)       DOCS="${DOCS}- ${msg}"$'\n' ;;
+              chore:*|chore\(*)     CHORE="${CHORE}- ${msg}"$'\n' ;;
+              *)                    CHORE="${CHORE}- ${line}"$'\n' ;;
+            esac
+          done <<< "$COMMITS"
+
+          # 버전 계산: 최근 RELEASE 커밋에서 현재 버전 추출
+          CURRENT_VERSION=$(git log --all --oneline --grep="\[RELEASE\]" --format="%s" | head -1 | sed 's/.*v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
+          if [ -z "$CURRENT_VERSION" ]; then
+            CURRENT_VERSION="0.0.0"
+          fi
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+          if [ -n "$FEAT" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEXT_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+
+          # PR 본문 생성
+          BODY="## [RELEASE] $NEXT_VERSION"
+          NEWLINE=$'\n'
+
+          if [ -n "$FEAT" ]; then
+            BODY="${BODY}${NEWLINE}${NEWLINE}### 기능${NEWLINE}${FEAT}"
+          fi
+
+          if [ -n "$FIX" ]; then
+            BODY="${BODY}${NEWLINE}${NEWLINE}### 버그 수정${NEWLINE}${FIX}"
+          fi
+
+          if [ -n "$REFACTOR" ]; then
+            BODY="${BODY}${NEWLINE}${NEWLINE}### 리팩토링${NEWLINE}${REFACTOR}"
+          fi
+
+          if [ -n "$STYLE" ]; then
+            BODY="${BODY}${NEWLINE}${NEWLINE}### 스타일${NEWLINE}${STYLE}"
+          fi
+
+          if [ -n "$DOCS" ]; then
+            BODY="${BODY}${NEWLINE}${NEWLINE}### 문서${NEWLINE}${DOCS}"
+          fi
+
+          if [ -n "$CHORE" ]; then
+            BODY="${BODY}${NEWLINE}${NEWLINE}### 기타${NEWLINE}${CHORE}"
+          fi
+
+          # multiline output
+          {
+            echo "body<<BODY_EOF"
+            echo "$BODY"
+            echo "BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update PR
+        if: steps.check.outputs.commit_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEXT_VERSION="${{ steps.generate.outputs.next_version }}"
+          TITLE="[RELEASE] $NEXT_VERSION"
+
+          # 기존 열린 PR 확인
+          EXISTING_PR=$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Updating existing PR #$EXISTING_PR"
+            gh pr edit "$EXISTING_PR" --title "$TITLE" --body "${{ steps.generate.outputs.body }}"
+          else
+            echo "Creating new PR"
+            gh pr create --base main --head dev --title "$TITLE" --body "${{ steps.generate.outputs.body }}"
+          fi

--- a/docs/superpowers/plans/2026-04-01-release-pr-automation.md
+++ b/docs/superpowers/plans/2026-04-01-release-pr-automation.md
@@ -1,0 +1,264 @@
+# Release PR 자동화 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** dev 브랜치에 push될 때 릴리즈 노트 형식의 dev → main PR을 자동 생성/업데이트하는 GitHub Actions 워크플로우 구현
+
+**Architecture:** 단일 GitHub Actions 워크플로우 파일 내 인라인 쉘 스크립트. 커밋 로그 파싱 → 타입별 분류 → semver 계산 → gh CLI로 PR 생성/업데이트.
+
+**Tech Stack:** GitHub Actions, Bash, gh CLI
+
+---
+
+## 파일 구조
+
+- **Create:** `.github/workflows/release-pr.yml` — 워크플로우 정의 및 전체 로직
+
+---
+
+### Task 1: 워크플로우 기본 구조 작성
+
+**Files:**
+- Create: `.github/workflows/release-pr.yml`
+
+- [ ] **Step 1: 워크플로우 트리거 및 권한 정의**
+
+```yaml
+name: Release PR
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+```
+
+`fetch-depth: 0`은 `main..dev` 커밋 비교를 위해 전체 히스토리 필요.
+
+- [ ] **Step 2: 커밋 차이 확인 step 추가**
+
+checkout 이후에 추가:
+
+```yaml
+      - name: Check for changes
+        id: check
+        run: |
+          COMMIT_COUNT=$(git rev-list --count origin/main..origin/dev 2>/dev/null || echo "0")
+          echo "commit_count=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COMMIT_COUNT" -eq 0 ]; then
+            echo "No commits between main and dev. Skipping."
+          fi
+```
+
+이후 모든 step에 조건 추가: `if: steps.check.outputs.commit_count != '0'`
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add .github/workflows/release-pr.yml
+git commit -m "feat: Release PR 자동화 워크플로우 기본 구조 추가"
+```
+
+---
+
+### Task 2: 커밋 파싱 및 분류 로직
+
+**Files:**
+- Modify: `.github/workflows/release-pr.yml`
+
+- [ ] **Step 1: 커밋 파싱 step 추가**
+
+check step 이후에 추가:
+
+```yaml
+      - name: Parse commits and generate body
+        if: steps.check.outputs.commit_count != '0'
+        id: generate
+        run: |
+          # 커밋 로그 수집 (Merge 커밋 제외)
+          COMMITS=$(git log origin/main..origin/dev --oneline --no-merges --format="%s")
+
+          # 타입별 분류
+          FEAT=""
+          FIX=""
+          REFACTOR=""
+          STYLE=""
+          DOCS=""
+          CHORE=""
+
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            case "$line" in
+              feat:*|feat\(*) FEAT="$FEAT
+          - ${line#feat: }" ;;
+              fix:*|fix\(*)   FIX="$FIX
+          - ${line#fix: }" ;;
+              refactor:*|refactor\(*) REFACTOR="$REFACTOR
+          - ${line#refactor: }" ;;
+              style:*|style\(*) STYLE="$STYLE
+          - ${line#style: }" ;;
+              docs:*|docs\(*)  DOCS="$DOCS
+          - ${line#docs: }" ;;
+              *)               CHORE="$CHORE
+          - ${line#chore: }" ;;
+            esac
+          done <<< "$COMMITS"
+
+          # 버전 계산: 최근 RELEASE 커밋에서 현재 버전 추출
+          CURRENT_VERSION=$(git log --all --oneline --grep="\[RELEASE\]" --format="%s" | head -1 | sed 's/.*v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
+          if [ -z "$CURRENT_VERSION" ]; then
+            CURRENT_VERSION="0.0.0"
+          fi
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+          if [ -n "$FEAT" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEXT_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+
+          # PR 본문 생성
+          BODY="## [RELEASE] $NEXT_VERSION"
+
+          if [ -n "$FEAT" ]; then
+            BODY="$BODY
+
+          ### 기능
+          $FEAT"
+          fi
+
+          if [ -n "$FIX" ]; then
+            BODY="$BODY
+
+          ### 버그 수정
+          $FIX"
+          fi
+
+          if [ -n "$REFACTOR" ]; then
+            BODY="$BODY
+
+          ### 리팩토링
+          $REFACTOR"
+          fi
+
+          if [ -n "$STYLE" ]; then
+            BODY="$BODY
+
+          ### 스타일
+          $STYLE"
+          fi
+
+          if [ -n "$DOCS" ]; then
+            BODY="$BODY
+
+          ### 문서
+          $DOCS"
+          fi
+
+          if [ -n "$CHORE" ]; then
+            BODY="$BODY
+
+          ### 기타
+          $CHORE"
+          fi
+
+          # multiline output
+          {
+            echo "body<<BODY_EOF"
+            echo "$BODY"
+            echo "BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add .github/workflows/release-pr.yml
+git commit -m "feat: 커밋 파싱, 타입별 분류 및 버전 계산 로직 추가"
+```
+
+---
+
+### Task 3: PR 생성/업데이트 로직
+
+**Files:**
+- Modify: `.github/workflows/release-pr.yml`
+
+- [ ] **Step 1: PR 생성/업데이트 step 추가**
+
+generate step 이후에 추가:
+
+```yaml
+      - name: Create or update PR
+        if: steps.check.outputs.commit_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEXT_VERSION="${{ steps.generate.outputs.next_version }}"
+          TITLE="[RELEASE] $NEXT_VERSION"
+          BODY="${{ steps.generate.outputs.body }}"
+
+          # 기존 열린 PR 확인
+          EXISTING_PR=$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Updating existing PR #$EXISTING_PR"
+            gh pr edit "$EXISTING_PR" --title "$TITLE" --body "$BODY"
+          else
+            echo "Creating new PR"
+            gh pr create --base main --head dev --title "$TITLE" --body "$BODY"
+          fi
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add .github/workflows/release-pr.yml
+git commit -m "feat: PR 자동 생성/업데이트 로직 추가"
+```
+
+---
+
+### Task 4: 최종 검증 및 통합 커밋
+
+**Files:**
+- Verify: `.github/workflows/release-pr.yml`
+
+- [ ] **Step 1: YAML 문법 검증**
+
+```bash
+# yamllint이 없으면 간단히 파싱 테스트
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-pr.yml'))" && echo "YAML valid"
+```
+
+- [ ] **Step 2: 워크플로우 전체 파일 리뷰**
+
+완성된 `.github/workflows/release-pr.yml` 전체를 읽고 다음을 확인:
+- 들여쓰기가 올바른지
+- step 간 output 참조가 일치하는지 (`steps.check.outputs.commit_count`, `steps.generate.outputs.next_version`, `steps.generate.outputs.body`)
+- `if` 조건이 모든 후속 step에 적용되었는지
+
+- [ ] **Step 3: 최종 커밋 (필요 시)**
+
+문제가 발견되어 수정한 경우:
+
+```bash
+git add .github/workflows/release-pr.yml
+git commit -m "fix: Release PR 워크플로우 수정"
+```

--- a/docs/superpowers/specs/2026-04-01-release-pr-automation-design.md
+++ b/docs/superpowers/specs/2026-04-01-release-pr-automation-design.md
@@ -1,0 +1,103 @@
+# Release PR 자동화 설계
+
+## 개요
+
+`dev` 브랜치에 변경사항이 push될 때마다, `dev → main` PR을 정해진 릴리즈 노트 형식으로 자동 생성/업데이트하는 GitHub Actions 워크플로우.
+
+## 트리거
+
+- **이벤트**: `dev` 브랜치에 `push`
+- **조건**: `main..dev` 커밋 차이가 1개 이상일 때만 동작
+
+```yaml
+on:
+  push:
+    branches: [dev]
+```
+
+## 워크플로우 동작 흐름
+
+1. `git log main..dev --oneline`으로 커밋 차이 수집
+2. 커밋 메시지를 타입별로 분류
+3. 현재 버전(`package.json`)에서 다음 버전 계산
+4. PR 본문 생성
+5. 기존 `dev → main` 열린 PR이 있으면 제목+본문 업데이트, 없으면 새로 생성
+
+## 커밋 분류 규칙
+
+| 커밋 prefix | 그룹명 |
+|---|---|
+| `feat:` | 기능 |
+| `fix:` | 버그 수정 |
+| `refactor:` | 리팩토링 |
+| `style:` | 스타일 |
+| `docs:` | 문서 |
+| `chore:` 및 기타 | 기타 |
+
+- Merge 커밋(`Merge branch`, `Merge remote-tracking`)은 제외
+- 커밋 메시지에서 prefix를 제거한 나머지를 항목으로 사용
+- PR 번호(`#123`)가 있으면 그대로 유지
+
+## 버전 계산
+
+- 현재 버전: 가장 최근 `[RELEASE] vX.X.X` 커밋 메시지에서 추출 (git log 기반)
+- `feat:` 커밋이 1개 이상 → **minor** bump (`v2.9.5` → `v2.10.0`)
+- `feat:` 없음 → **patch** bump (`v2.9.5` → `v2.9.6`)
+- `feat!:` / `BREAKING CHANGE`가 있어도 **minor까지만** (major는 수동 판단)
+
+## PR 형식
+
+**제목**: `[RELEASE] v2.10.0`
+
+**본문**:
+
+```markdown
+## [RELEASE] v2.10.0
+
+### 기능
+- Spring 2026 랜딩 페이지 업데이트 (#370)
+- 퀴즈 관리 페이지 모바일 최적화 및 UI 개선 (#369)
+
+### 리팩토링
+- PandaCSS에서 Tailwind CSS로 스타일링 시스템 마이그레이션 (#356)
+
+### 기타
+- git ignore 추가
+```
+
+- 해당 타입의 커밋이 없으면 그 섹션은 생략
+- 아이콘/이모지 사용하지 않음
+
+## PR 생성/업데이트 로직
+
+1. `gh pr list --base main --head dev --state open --json number`로 기존 PR 확인
+2. **기존 PR 있음** → `gh pr edit <number> --title "..." --body "..."`
+3. **기존 PR 없음** → `gh pr create --base main --head dev --title "..." --body "..."`
+4. **커밋 차이 없음** → 아무것도 하지 않고 종료
+
+## 파일 구조
+
+```
+.github/
+  workflows/
+    release-pr.yml    # 워크플로우 정의 + 쉘 스크립트 인라인
+```
+
+로직이 단순하므로 별도 스크립트 파일 없이 워크플로우 내 인라인 쉘 스크립트로 구현.
+
+## 권한
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+`GITHUB_TOKEN` 기본 권한으로 충분. 별도 시크릿 불필요.
+
+## 범위 외 (Out of Scope)
+
+- 라벨 자동 지정
+- assignee / reviewer 자동 지정 (기존 `auto_assign.yml`에 위임)
+- `package.json` 버전 자동 업데이트 (PR 본문에 버전 표시만)
+- changelog 파일 생성


### PR DESCRIPTION
## Summary
- dev 브랜치에 push 시 커밋 타입별 릴리즈 노트를 자동 생성하는 GitHub Actions 워크플로우 추가
- 기존 dev → main PR이 있으면 업데이트, 없으면 새로 생성
- 커밋 컨벤션(feat/fix/refactor 등) 기반 분류 + semver 자동 계산

## 변경 파일
- `.github/workflows/release-pr.yml` — 워크플로우 본체
- `docs/superpowers/specs/` — 설계 스펙
- `docs/superpowers/plans/` — 구현 계획

## 동작 방식
1. `dev` push → 워크플로우 트리거
2. `main..dev` 커밋 파싱 → 타입별 그룹핑
3. 최근 `[RELEASE]` 커밋에서 버전 추출 → semver bump
4. `gh pr create/edit`로 PR 생성/업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)