### PR TITLE
Claude Code 연동 페이지 추가 (web, webview)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ apps/admin-main/.env.local
 apps/admin-main/docs/superpowers
 .omc
 
+.superpowers
+docs/superpowers
+
+

--- a/apps/web/src/app/[locale]/auth/claude-code/page.tsx
+++ b/apps/web/src/app/[locale]/auth/claude-code/page.tsx
@@ -1,19 +1,29 @@
+'use client';
+
 import { useState } from 'react';
-import { Navigate } from 'react-router-dom';
-import { authUtils } from '@/utils';
-import { useUser } from '@/hooks/useUser';
-import { ROUTES } from '@/router/constants';
+import { signIn } from 'next-auth/react';
+import { useClientSession, useClientUser } from '@/shared/utils/clientAuth';
 
 export default function ClaudeCodePage() {
   const [copied, setCopied] = useState(false);
-  const isAuthenticated = authUtils.isAuthenticated();
-  const user = useUser();
+  const { status } = useClientSession();
+  const user = useClientUser();
 
-  if (!isAuthenticated) {
-    return <Navigate to={ROUTES.AUTH} replace state={{ from: { pathname: '/auth/claude-code' } }} />;
+  if (status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <span className="text-gray-500">Loading...</span>
+      </div>
+    );
   }
 
-  const command = `/gitanimals-buddy:login ${user.username}`;
+  if (status === 'unauthenticated') {
+    signIn(undefined, { callbackUrl: '/auth/claude-code' });
+    return null;
+  }
+
+  const username = user.name ?? '';
+  const command = `/gitanimals-buddy:login ${username}`;
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(command);
@@ -29,19 +39,17 @@ export default function ClaudeCodePage() {
           <h1 className="mt-4 text-2xl font-bold text-gray-900">Claude Code 연동</h1>
         </div>
 
-        <p className="mb-2 text-center text-gray-600">
-          당신의 username은
-        </p>
-        <p className="mb-6 text-center text-xl font-bold text-gray-900">{user.username}</p>
+        <p className="mb-2 text-center text-gray-600">당신의 username은</p>
+        <p className="mb-6 text-center text-xl font-bold text-gray-900">{username}</p>
 
         <p className="mb-3 text-sm text-gray-500">아래 명령어를 Claude Code 터미널에 입력하세요:</p>
 
         <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-          <code className="flex-1 text-sm font-mono text-gray-800">{command}</code>
+          <code className="flex-1 font-mono text-sm text-gray-800">{command}</code>
           <button
             type="button"
             onClick={handleCopy}
-            className="shrink-0 rounded-md bg-brand-canary px-3 py-1.5 text-sm font-semibold transition-opacity hover:opacity-80 active:opacity-60"
+            className="shrink-0 rounded-md bg-yellow-300 px-3 py-1.5 text-sm font-semibold transition-opacity hover:opacity-80 active:opacity-60"
           >
             {copied ? '복사됨 ✓' : '복사'}
           </button>

--- a/apps/web/src/app/[locale]/auth/claude-code/page.tsx
+++ b/apps/web/src/app/[locale]/auth/claude-code/page.tsx
@@ -1,20 +1,19 @@
 'use client';
 
-import { useState } from 'react';
 import { signIn } from 'next-auth/react';
-import { TextField } from '@gitanimals/ui-tailwind';
+import { css } from '_panda/css';
+import { TextField } from '@gitanimals/ui-panda';
 
-import { useClientSession, useClientUser } from '@/shared/utils/clientAuth';
+import { useClientSession, useClientUser } from '@/utils/clientAuth';
 
 export default function ClaudeCodePage() {
-  const [copied, setCopied] = useState(false);
   const { status } = useClientSession();
   const user = useClientUser();
 
   if (status === 'loading') {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-brand-primary">
-        <span className="text-white/70">Loading...</span>
+      <div className={pageRootCss}>
+        <p className={loadingTextCss}>로딩 중…</p>
       </div>
     );
   }
@@ -27,30 +26,116 @@ export default function ClaudeCodePage() {
   const username = user.name ?? '';
   const command = `/gitanimals-buddy:login ${username}`;
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-brand-primary px-6">
-      <div className="w-fit h-fit bg-white-10 rounded-lg p-6 flex flex-col items-center justify-center gap-6 min-w-[520px] px-10">
-        <div className="text-center">
-          <p className="text-glyph-82 font-[64px] leading-none">🐾</p>
-          <h1 className="mt-6 text-glyph-28 font-bold text-white">Claude Code 연동</h1>
+    <div className={pageRootCss}>
+      <div className={cardCss}>
+        <div className={headerBlockCss}>
+          <p className={emojiCss}>🐾</p>
+          <h1 className={titleCss}>Claude Code 연동</h1>
         </div>
 
-        <div className="text-center">
-          <p className="text-glyph-20 text-white/80">당신의 username은</p>
-          <p className="mt-1 text-glyph-28 font-bold text-white">{username}</p>
+        <div className={usernameBlockCss}>
+          <p className={mutedLabelCss}>당신의 username은</p>
+          <p className={usernameValueCss}>{username}</p>
         </div>
 
-        <div className="w-full ">
-          <p className="mb-3 text-glyph-14 text-white/70">아래 명령어를 Claude Code 터미널에 입력하세요</p>
-          <TextField readOnly value={command} className="text-glyph-14 w-full" />
+        <div className={commandBlockCss}>
+          <p className={commandHintCss}>아래 명령어를 Claude Code 터미널에 입력하세요</p>
+          <TextField readOnly value={command} />
         </div>
       </div>
     </div>
   );
 }
+
+/** 상점 Auction 섹션과 동일 그라데이션 */
+const pageRootCss = css({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: '100vh',
+  padding: '24px',
+  bg: 'linear-gradient(180deg, #000 0%, #004875 38.51%, #005B93 52.46%, #006FB3 73.8%, #0187DB 100%)',
+
+  _mobile: {
+    padding: '16px',
+  },
+});
+
+const loadingTextCss = css({
+  textStyle: 'glyph20.regular',
+  color: 'white.white_70',
+});
+
+const cardCss = css({
+  borderRadius: '16px',
+  background: 'rgba(255, 255, 255, 0.1)',
+  backdropFilter: 'blur(7px)',
+  padding: '40px',
+  width: 'fit-content',
+  minWidth: '520px',
+  maxWidth: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '24px',
+
+  _mobile: {
+    minWidth: '100%',
+    padding: '24px 16px',
+    background: 'rgba(255, 255, 255, 0.08)',
+  },
+});
+
+const headerBlockCss = css({
+  textAlign: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '24px',
+});
+
+const emojiCss = css({
+  textStyle: 'glyph82.bold',
+  lineHeight: '1',
+});
+
+const titleCss = css({
+  textStyle: 'glyph28.bold',
+  color: 'white',
+
+  _mobile: {
+    textStyle: 'glyph24.bold',
+  },
+});
+
+const usernameBlockCss = css({
+  textAlign: 'center',
+});
+
+const mutedLabelCss = css({
+  textStyle: 'glyph20.regular',
+  color: 'white.white_80',
+});
+
+const usernameValueCss = css({
+  textStyle: 'glyph28.bold',
+  color: 'white',
+  marginTop: '4px',
+
+  _mobile: {
+    textStyle: 'glyph24.bold',
+  },
+});
+
+const commandBlockCss = css({
+  width: '100%',
+  textAlign: 'center',
+});
+
+const commandHintCss = css({
+  textStyle: 'glyph14.regular',
+  color: 'white.white_70',
+  marginBottom: '12px',
+});

--- a/apps/web/src/app/[locale]/auth/claude-code/page.tsx
+++ b/apps/web/src/app/[locale]/auth/claude-code/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
-import { Button, TextField } from '@gitanimals/ui-tailwind';
+import { TextField } from '@gitanimals/ui-tailwind';
+
 import { useClientSession, useClientUser } from '@/shared/utils/clientAuth';
 
 export default function ClaudeCodePage() {
@@ -34,29 +35,20 @@ export default function ClaudeCodePage() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-brand-primary px-6">
-      <div className="text-center">
-        <p className="text-5xl leading-none">🐾</p>
-        <h1 className="mt-6 text-4xl font-bold text-white">Claude Code 연동</h1>
-      </div>
+      <div className="w-fit h-fit bg-white-10 rounded-lg p-6 flex flex-col items-center justify-center gap-6 min-w-[520px] px-10">
+        <div className="text-center">
+          <p className="text-glyph-82 font-[64px] leading-none">🐾</p>
+          <h1 className="mt-6 text-glyph-28 font-bold text-white">Claude Code 연동</h1>
+        </div>
 
-      <div className="text-center">
-        <p className="text-lg text-white/80">당신의 username은</p>
-        <p className="mt-1 text-3xl font-bold text-white">{username}</p>
-      </div>
+        <div className="text-center">
+          <p className="text-glyph-20 text-white/80">당신의 username은</p>
+          <p className="mt-1 text-glyph-28 font-bold text-white">{username}</p>
+        </div>
 
-      <div className="w-full max-w-[520px]">
-        <p className="mb-3 font-product text-glyph-14 text-white/70">
-          아래 명령어를 Claude Code 터미널에 입력하세요:
-        </p>
-        <div className="flex items-center gap-3">
-          <TextField
-            readOnly
-            value={command}
-            className="font-mono text-glyph-14"
-          />
-          <Button variant="primary" size="m" onClick={handleCopy} className="shrink-0">
-            {copied ? '복사됨 ✓' : '복사'}
-          </Button>
+        <div className="w-full ">
+          <p className="mb-3 text-glyph-14 text-white/70">아래 명령어를 Claude Code 터미널에 입력하세요</p>
+          <TextField readOnly value={command} className="text-glyph-14 w-full" />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/[locale]/auth/claude-code/page.tsx
+++ b/apps/web/src/app/[locale]/auth/claude-code/page.tsx
@@ -11,8 +11,8 @@ export default function ClaudeCodePage() {
 
   if (status === 'loading') {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <span className="text-gray-500">Loading...</span>
+      <div className="flex min-h-screen items-center justify-center bg-brand-primary">
+        <span className="text-white/70">Loading...</span>
       </div>
     );
   }
@@ -32,24 +32,25 @@ export default function ClaudeCodePage() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-gray-50 p-8">
-      <div className="w-full max-w-[480px] rounded-2xl bg-white p-8 shadow-lg">
-        <div className="mb-6 text-center">
-          <span className="text-5xl leading-none">🐾</span>
-          <h1 className="mt-4 text-2xl font-bold text-gray-900">Claude Code 연동</h1>
-        </div>
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-brand-primary px-6">
+      <div className="text-center">
+        <p className="text-5xl leading-none">🐾</p>
+        <h1 className="mt-6 text-4xl font-bold text-white">Claude Code 연동</h1>
+      </div>
 
-        <p className="mb-2 text-center text-gray-600">당신의 username은</p>
-        <p className="mb-6 text-center text-xl font-bold text-gray-900">{username}</p>
+      <div className="text-center">
+        <p className="text-lg text-white/80">당신의 username은</p>
+        <p className="mt-1 text-3xl font-bold text-white">{username}</p>
+      </div>
 
-        <p className="mb-3 text-sm text-gray-500">아래 명령어를 Claude Code 터미널에 입력하세요:</p>
-
-        <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-          <code className="flex-1 font-mono text-sm text-gray-800">{command}</code>
+      <div className="w-full max-w-[520px]">
+        <p className="mb-3 text-sm text-white/70">아래 명령어를 Claude Code 터미널에 입력하세요:</p>
+        <div className="flex items-center gap-3 rounded-2xl border-2 border-white/20 bg-white/10 px-5 py-4 backdrop-blur-sm">
+          <code className="flex-1 font-mono text-sm text-white">{command}</code>
           <button
             type="button"
             onClick={handleCopy}
-            className="shrink-0 rounded-md bg-yellow-300 px-3 py-1.5 text-sm font-semibold transition-opacity hover:opacity-80 active:opacity-60"
+            className="shrink-0 rounded-xl border-2 border-brand-canary bg-brand-canary px-4 py-2 text-sm font-bold text-black transition-opacity hover:opacity-80 active:opacity-60"
           >
             {copied ? '복사됨 ✓' : '복사'}
           </button>

--- a/apps/web/src/app/[locale]/auth/claude-code/page.tsx
+++ b/apps/web/src/app/[locale]/auth/claude-code/page.tsx
@@ -30,7 +30,25 @@ export default function ClaudeCodePage() {
     <div className={pageRootCss}>
       <div className={cardCss}>
         <div className={headerBlockCss}>
-          <p className={emojiCss}>🐾</p>
+          <p className={emojiCss}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="52"
+              height="52"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#ffffff"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              className="lucide lucide-paw-print-icon lucide-paw-print"
+            >
+              <circle cx="11" cy="4" r="2" />
+              <circle cx="18" cy="8" r="2" />
+              <circle cx="20" cy="16" r="2" />
+              <path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z" />
+            </svg>
+          </p>
           <h1 className={titleCss}>Claude Code 연동</h1>
         </div>
 
@@ -57,7 +75,7 @@ const pageRootCss = css({
   minHeight: '100vh',
   padding: '24px',
   bg: 'linear-gradient(180deg, #000 0%, #004875 38.51%, #005B93 52.46%, #006FB3 73.8%, #0187DB 100%)',
-
+  color: 'white',
   _mobile: {
     padding: '16px',
   },
@@ -99,6 +117,7 @@ const headerBlockCss = css({
 const emojiCss = css({
   textStyle: 'glyph82.bold',
   lineHeight: '1',
+  color: 'white,',
 });
 
 const titleCss = css({

--- a/apps/web/src/app/[locale]/auth/claude-code/page.tsx
+++ b/apps/web/src/app/[locale]/auth/claude-code/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
+import { Button, TextField } from '@gitanimals/ui-tailwind';
 import { useClientSession, useClientUser } from '@/shared/utils/clientAuth';
 
 export default function ClaudeCodePage() {
@@ -44,16 +45,18 @@ export default function ClaudeCodePage() {
       </div>
 
       <div className="w-full max-w-[520px]">
-        <p className="mb-3 text-sm text-white/70">아래 명령어를 Claude Code 터미널에 입력하세요:</p>
-        <div className="flex items-center gap-3 rounded-2xl border-2 border-white/20 bg-white/10 px-5 py-4 backdrop-blur-sm">
-          <code className="flex-1 font-mono text-sm text-white">{command}</code>
-          <button
-            type="button"
-            onClick={handleCopy}
-            className="shrink-0 rounded-xl border-2 border-brand-canary bg-brand-canary px-4 py-2 text-sm font-bold text-black transition-opacity hover:opacity-80 active:opacity-60"
-          >
+        <p className="mb-3 font-product text-glyph-14 text-white/70">
+          아래 명령어를 Claude Code 터미널에 입력하세요:
+        </p>
+        <div className="flex items-center gap-3">
+          <TextField
+            readOnly
+            value={command}
+            className="font-mono text-glyph-14"
+          />
+          <Button variant="primary" size="m" onClick={handleCopy} className="shrink-0">
             {copied ? '복사됨 ✓' : '복사'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/webview/src/pages/auth/ClaudeCodePage.tsx
+++ b/apps/webview/src/pages/auth/ClaudeCodePage.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import { authUtils } from '@/utils';
+import { useUser } from '@/hooks/useUser';
+import { ROUTES } from '@/router/constants';
+
+export default function ClaudeCodePage() {
+  const [copied, setCopied] = useState(false);
+  const isAuthenticated = authUtils.isAuthenticated();
+  const user = useUser();
+
+  if (!isAuthenticated) {
+    return <Navigate to={ROUTES.AUTH} replace state={{ from: { pathname: '/auth/claude-code' } }} />;
+  }
+
+  const command = `/gitanimals-buddy:login ${user.username}`;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-gray-50 p-8">
+      <div className="w-full max-w-[480px] rounded-2xl bg-white p-8 shadow-lg">
+        <div className="mb-6 text-center">
+          <span className="text-5xl leading-none">🐾</span>
+          <h1 className="mt-4 text-2xl font-bold text-gray-900">Claude Code 연동</h1>
+        </div>
+
+        <p className="mb-2 text-center text-gray-600">
+          당신의 username은
+        </p>
+        <p className="mb-6 text-center text-xl font-bold text-gray-900">{user.username}</p>
+
+        <p className="mb-3 text-sm text-gray-500">아래 명령어를 Claude Code 터미널에 입력하세요:</p>
+
+        <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+          <code className="flex-1 text-sm font-mono text-gray-800">{command}</code>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="shrink-0 rounded-md bg-brand-canary px-3 py-1.5 text-sm font-semibold transition-opacity hover:opacity-80 active:opacity-60"
+          >
+            {copied ? '복사됨 ✓' : '복사'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/webview/src/router/index.tsx
+++ b/apps/webview/src/router/index.tsx
@@ -12,7 +12,6 @@ import SolveQuizPage from '@/pages/game/quiz/solve/page';
 import CreateQuizPage from '@/pages/game/quiz/create/page';
 import ShopPage from '@/pages/shop/page';
 import LoginPage from '@/pages/auth/LoginPage';
-import ClaudeCodePage from '@/pages/auth/ClaudeCodePage';
 
 export const router = createBrowserRouter([
   {
@@ -87,10 +86,7 @@ export const router = createBrowserRouter([
             path: 'login',
             element: <LoginPage />,
           },
-          {
-            path: 'claude-code',
-            element: <ClaudeCodePage />,
-          },
+
         ],
       },
       {

--- a/apps/webview/src/router/index.tsx
+++ b/apps/webview/src/router/index.tsx
@@ -12,6 +12,7 @@ import SolveQuizPage from '@/pages/game/quiz/solve/page';
 import CreateQuizPage from '@/pages/game/quiz/create/page';
 import ShopPage from '@/pages/shop/page';
 import LoginPage from '@/pages/auth/LoginPage';
+import ClaudeCodePage from '@/pages/auth/ClaudeCodePage';
 
 export const router = createBrowserRouter([
   {
@@ -77,11 +78,18 @@ export const router = createBrowserRouter([
       // 공개 라우트들 (인증 불필요)
       {
         path: NESTED_PATHS.AUTH(),
-        element: <LoginPage />,
         children: [
+          {
+            index: true,
+            element: <LoginPage />,
+          },
           {
             path: 'login',
             element: <LoginPage />,
+          },
+          {
+            path: 'claude-code',
+            element: <ClaudeCodePage />,
           },
         ],
       },

--- a/packages/ui/panda/src/components/Textfield/TextField.tsx
+++ b/packages/ui/panda/src/components/Textfield/TextField.tsx
@@ -3,11 +3,12 @@ import { ComponentProps } from 'react';
 
 interface TextFieldProps extends ComponentProps<'input'> {
   error?: string;
+  containerClassName?: string;
 }
 
-export const TextField = ({ error, ...props }: TextFieldProps) => {
+export const TextField = ({ error, containerClassName, ...props }: TextFieldProps) => {
   return (
-    <div>
+    <div className={cx(containerClassName)}>
       <input type="text" {...props} className={cx(textFieldStyle, props.className)} />
       {error && <p className={errorStyle}>{error}</p>}
     </div>


### PR DESCRIPTION
## 💻 작업 내용

### Claude Code 연동 페이지 신규 추가 (`/auth/claude-code`)

**web 앱 (`apps/web`)**
- `/auth/claude-code` 라우트에 Claude Code 연동 안내 페이지 추가
- 로그인된 사용자의 GitHub username을 기반으로 `/gitanimals-buddy:login <username>` 명령어를 자동 생성하여 표시
- 미인증 상태일 경우 로그인 페이지로 자동 리다이렉트 후 콜백 처리
- PandaCSS 디자인 토큰 및 텍스트 스타일 적용, 기존 경매 섹션과 동일한 블루 그라데이션 배경 사용
- 헤더 아이콘을 이모지(`🐾`)에서 Lucide paw-print SVG 아이콘으로 교체
- `TextField` 컴포넌트에 `containerClassName` prop 추가하여 외부에서 래퍼 스타일링 가능하도록 개선
- 반응형 레이아웃 적용 (`_mobile` 조건)

**webview 앱 (`apps/webview`)**
- `/auth/claude-code` 라우트 추가
- 라우터 구조 개선: `AUTH` 경로에 `index` 라우트를 명시적으로 분리하여 중첩 라우팅 정리

### 변경 목적
GitAnimals Buddy Claude Code 플러그인과 연동하기 위한 로그인 연동 페이지 제공. 사용자가 웹에서 로그인 후 자신의 username으로 생성된 Claude Code 명령어를 바로 복사해 사용할 수 있도록 UX 개선.

## 📸 스크린샷

UI 변경사항 있음 — `/auth/claude-code` 신규 페이지 (블루 그라데이션 배경, 반투명 카드, 명령어 입력창 표시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Claude Code 인증 페이지가 추가되었습니다.

* **Improvements**
  * TextField 컴포넌트의 스타일링 옵션이 향상되었습니다.

* **Chores**
  * 파일 무시 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->