### PR TITLE
fix: 데스크톱 로그인 핸드오프 localhost 허용

### DIFF
--- a/apps/web/src/constants/desktopAuth.ts
+++ b/apps/web/src/constants/desktopAuth.ts
@@ -1,5 +1,5 @@
 export const DESKTOP_REDIRECT_PATTERN =
-  /^http:\/\/127\.0\.0\.1:(2333[8-9]|2334[0-2])\/auth\/callback$/;
+  /^http:\/\/(127\.0\.0\.1|localhost):(2333[8-9]|2334[0-2])\/auth\/callback$/;
 
 export function isValidDesktopRedirect(url: string | null | undefined): url is string {
   return typeof url === 'string' && DESKTOP_REDIRECT_PATTERN.test(url);


### PR DESCRIPTION
## Summary

- 프로덕션에서 `127.0.0.1`이 `localhost`로 정규화되는 외부 이슈(apex→www 리디렉트)로 인해 화이트리스트 검증 실패하는 버그 수정
- `DESKTOP_REDIRECT_PATTERN`에 `localhost` 추가 (`127.0.0.1|localhost`)
- 포트 범위 `23338-23342`, 경로 `/auth/callback`, 스킴 `http://` 제약은 유지

> **스펙과의 차이**: 원 스펙(`2026-04-20-web-login-handoff.md` §1)은 `localhost` 불허, `127.0.0.1`만 허용. 프로덕션 환경에서 정규화가 우리 코드 외부에서 발생해 실사용 불가능한 제약이라 완화. 데스크톱팀 공유 필요.

## Test plan

- [ ] `https://www.gitanimals.org/auth/desktop?redirect_uri=http://localhost:23338/auth/callback&state=abc123` → OAuth 진입 후 콜백 리디렉트 확인
- [ ] `127.0.0.1` 경로도 기존과 동일하게 동작 확인
- [ ] `https://evil.com:23338/auth/callback` → 여전히 에러 페이지

🤖 Generated with [Claude Code](https://claude.com/claude-code)