### PR TITLE
feat: Mixpanel 사용자 포인트 속성 동기화 및 옥션 구매 이벤트 추가

### DIFF
--- a/apps/web/src/app/[locale]/auth/LoginButton.tsx
+++ b/apps/web/src/app/[locale]/auth/LoginButton.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { signIn } from 'next-auth/react';
 
-import { LOCAL_STORAGE_KEY } from '@/constants/storage';
+import { LOCAL_STORAGE_KEY, SESSION_STORAGE_KEY } from '@/constants/storage';
 
 function LoginButton({ token }: { token: string }) {
   const ref = React.useRef<HTMLButtonElement>(null);
@@ -18,6 +18,11 @@ function LoginButton({ token }: { token: string }) {
   const callbackUrl = localStorage.getItem(LOCAL_STORAGE_KEY.callbackUrl) || '/mypage';
 
   const handleLogin = async () => {
+    // complete_login 이벤트는 로그인 성공 직후 redirect(true)로 페이지가 즉시 전환되어
+    // 이 자리에서 직접 트래킹할 수 없다. 대신 "방금 로그인함" 플래그를 sessionStorage에 남겨두고,
+    // 리다이렉트된 페이지에서 세션이 authenticated로 잡히는 시점에 useSyncAnalyticsUser가 1회 발사한다.
+    sessionStorage.setItem(SESSION_STORAGE_KEY.justLoggedIn, 'true');
+
     await signIn('web-credentials', {
       token,
       callbackUrl,

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
-import { ClientProvider, GlobalComponent, Monitoring } from '@/components/Global';
+import { ClientProvider, GlobalComponent } from '@/components/Global';
 import { config } from '@/constants/config';
 import type { Locale } from '@/i18n/routing';
 import { LOCALE_LIST } from '@/i18n/routing';
@@ -43,8 +43,6 @@ export default async function LocaleLayout({
   return (
     <html lang={locale}>
       <body>
-        <Monitoring />
-
         <NextIntlClientProvider messages={messages}>
           <NuqsAdapter>
             <ClientProvider>

--- a/apps/web/src/app/[locale]/mypage/my-pet/SelectedPetTable.tsx
+++ b/apps/web/src/app/[locale]/mypage/my-pet/SelectedPetTable.tsx
@@ -15,7 +15,9 @@ import { overlay } from 'overlay-kit';
 import { toast } from 'sonner';
 
 import { LOCAL_STORAGE_KEY } from '@/constants/storage';
+import { trackEvent } from '@/lib/analytics';
 import { ANIMAL_TIER_TEXT_MAP, getAnimalTierInfo } from '@/utils/animals';
+import { useClientUser } from '@/utils/clientAuth';
 import { getPersonaImage } from '@/utils/image';
 
 import { EvolutionPersona } from './(evolution)';
@@ -30,6 +32,7 @@ export function SelectedPetTable({ currentPersona, reset }: SelectedPetTableProp
   const queryClient = useQueryClient();
 
   const t = useTranslations('Shop');
+  const { id: myId } = useClientUser();
   const [sellPersonaId, setSellPersonaId] = useState<string | null>(null);
   const { setDoNotShowAgain, isChecked: isDoNotShowAgain } = useDoNotShowAgain();
 
@@ -38,6 +41,19 @@ export function SelectedPetTable({ currentPersona, reset }: SelectedPetTableProp
     onSuccess: (data) => {
       toast.success((t('pet-sold') as string).replace('[money]', data.givenPoint.toString()));
       queryClient.invalidateQueries({ queryKey: userQueries.allKey() });
+
+      if (currentPersona) {
+        trackEvent('click_pet_sell', {
+          pet_name: currentPersona.type,
+          pet_price: 100,
+          pet_grade: ANIMAL_TIER_TEXT_MAP[getAnimalTierInfo(Number(currentPersona.dropRate.replace('%', '')))],
+          pet_level: Number(currentPersona.level),
+          page_name: 'mypage',
+          location: 'my_pet',
+          seller_id: String(myId),
+        });
+      }
+
       setSellPersonaId(null);
       reset();
     },

--- a/apps/web/src/app/[locale]/shop/_auction/ProductTable.tsx
+++ b/apps/web/src/app/[locale]/shop/_auction/ProductTable.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 
 import { MediaQuery } from '@/components/MediaQuery';
 import Pagination from '@/components/Pagination/Pagination';
+import { trackEvent } from '@/lib/analytics';
 import { useLoading } from '@/store/loading';
 import { useClientUser } from '@/utils/clientAuth';
 
@@ -80,7 +81,14 @@ function ProductTableRow({ product }: { product: Product }) {
       toast.success(t('buy-product-success'), {
         duration: 1000,
       });
+
+      trackEvent('click_auction_buy', {
+        productId: product.id,
+        price: product.price,
+      });
+
       queryClient.invalidateQueries({ queryKey: auctionQueries.productsKey() });
+      // 유저 쿼리 invalidate → useSyncAnalyticsUser가 갱신된 포인트를 사용자 속성으로 재동기화
       queryClient.invalidateQueries({ queryKey: userQueries.allKey() });
     },
     onSettled: () => {

--- a/apps/web/src/app/[locale]/shop/_auction/ProductTable.tsx
+++ b/apps/web/src/app/[locale]/shop/_auction/ProductTable.tsx
@@ -12,8 +12,10 @@ import { toast } from 'sonner';
 
 import { MediaQuery } from '@/components/MediaQuery';
 import Pagination from '@/components/Pagination/Pagination';
+import { useGetPersonaTier } from '@/hooks/persona/useGetPersonaDropRate';
 import { trackEvent } from '@/lib/analytics';
 import { useLoading } from '@/store/loading';
+import { ANIMAL_TIER_TEXT_MAP } from '@/utils/animals';
 import { useClientUser } from '@/utils/clientAuth';
 
 import { ShopTableDesktopRow, ShopTableMobileRow, ShopTableRowViewSkeleton } from '../_common/ShopTableMobileRow';
@@ -75,6 +77,7 @@ function ProductTableRow({ product }: { product: Product }) {
   const t = useTranslations('Shop');
 
   const productStatus = product.sellerId === myId ? 'MY_SELLING' : product.paymentState;
+  const petTier = useGetPersonaTier(product.persona.personaType);
 
   const { mutate: buyProduct, isPending: isBuying } = useBuyProduct({
     onSuccess: () => {
@@ -83,8 +86,11 @@ function ProductTableRow({ product }: { product: Product }) {
       });
 
       trackEvent('click_auction_buy', {
-        productId: product.id,
-        price: product.price,
+        pet_name: product.persona.personaType,
+        pet_price: product.price,
+        pet_level: product.persona.personaLevel,
+        pet_grade: ANIMAL_TIER_TEXT_MAP[petTier],
+        seller_id: product.sellerId,
       });
 
       queryClient.invalidateQueries({ queryKey: auctionQueries.productsKey() });

--- a/apps/web/src/app/[locale]/shop/_auction/SellSection/SellInputRow.tsx
+++ b/apps/web/src/app/[locale]/shop/_auction/SellSection/SellInputRow.tsx
@@ -13,7 +13,9 @@ import { toast } from 'sonner';
 
 import { useRegisterProduct } from '@/apis/auctions/useRegisterProduct';
 import { useGetPersonaTier } from '@/hooks/persona/useGetPersonaDropRate';
+import { trackEvent } from '@/lib/analytics';
 import { ANIMAL_TIER_TEXT_MAP } from '@/utils/animals';
+import { useClientUser } from '@/utils/clientAuth';
 import { getPersonaImage } from '@/utils/image';
 
 import { rowStyle, ShopTableMobileRow } from '../../_common/ShopTableMobileRow';
@@ -33,13 +35,24 @@ function SellInputRow({ item, initPersona }: Props) {
   const [isSellPriceModalOpen, setIsSellPriceModalOpen] = useState(false);
 
   const queryClient = useQueryClient();
+  const { id: myId } = useClientUser();
 
   const personaTier = useGetPersonaTier(item.type);
 
   const { mutate } = useRegisterProduct({
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: userQueries.allPersonasKey() });
       queryClient.invalidateQueries({ queryKey: auctionQueries.myProductsKey() });
+
+      trackEvent('click_pet_sell', {
+        pet_name: item.type,
+        pet_price: variables.price,
+        pet_grade: ANIMAL_TIER_TEXT_MAP[personaTier],
+        pet_level: Number(item.level),
+        page_name: 'shop',
+        location: 'auction_my_pet',
+        seller_id: String(myId),
+      });
 
       initPersona();
       resetPrice();

--- a/apps/web/src/components/Global/Monitoring.tsx
+++ b/apps/web/src/components/Global/Monitoring.tsx
@@ -8,12 +8,15 @@ import { Analytics } from '@vercel/analytics/react';
 
 import { config, MONITORING_KEY } from '@/constants/config';
 import { isProd } from '@/constants/env';
+import { useSyncAnalyticsUser } from '@/hooks/useSyncAnalyticsUser';
 import { usePathname } from '@/i18n/routing';
 import { initAnalytics, trackPageView } from '@/lib/analytics';
 
 function Monitoring() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  useSyncAnalyticsUser();
 
   useEffect(() => {
     initAnalytics();

--- a/apps/web/src/constants/storage.ts
+++ b/apps/web/src/constants/storage.ts
@@ -3,6 +3,10 @@ export const LOCAL_STORAGE_KEY = {
   isDoNotShowAgain: '@gitanimals/isDoNotShowAgain',
 } as const;
 
+export const SESSION_STORAGE_KEY = {
+  justLoggedIn: '@gitanimals/justLoggedIn',
+} as const;
+
 export const COOKIE_KEY = {
   locale: '@gitanimals/locale',
 };

--- a/apps/web/src/hooks/useSyncAnalyticsUser.ts
+++ b/apps/web/src/hooks/useSyncAnalyticsUser.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { userQueries } from '@gitanimals/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import { identifyUser, resetAnalyticsUser, setUserProperties } from '@/lib/analytics';
+import { useClientSession } from '@/utils/clientAuth';
+
+/**
+ * 로그인한 사용자를 Mixpanel에 식별하고, 포인트를 사용자 속성으로 동기화한다.
+ * - 세션 id가 잡히면 identify, 로그아웃하면 reset
+ * - 유저 쿼리의 points가 바뀔 때마다 people.set으로 항상 동기화
+ *   (옥션 구매 등으로 유저 쿼리가 invalidate되면 자동으로 갱신됨)
+ */
+export function useSyncAnalyticsUser() {
+  const { data: session, status } = useClientSession();
+  const userId = String(session?.user?.id ?? '');
+
+  const { data: user } = useQuery({
+    ...userQueries.userOptions(),
+    enabled: Boolean(userId),
+  });
+
+  useEffect(() => {
+    if (status === 'loading') return;
+
+    if (userId) {
+      identifyUser(userId);
+    } else {
+      resetAnalyticsUser();
+    }
+  }, [status, userId]);
+
+  useEffect(() => {
+    if (!user) return;
+    setUserProperties({ points: Number(user.points) });
+  }, [user?.points]);
+}

--- a/apps/web/src/hooks/useSyncAnalyticsUser.ts
+++ b/apps/web/src/hooks/useSyncAnalyticsUser.ts
@@ -4,7 +4,8 @@ import { useEffect } from 'react';
 import { userQueries } from '@gitanimals/react-query';
 import { useQuery } from '@tanstack/react-query';
 
-import { identifyUser, resetAnalyticsUser, setUserProperties } from '@/lib/analytics';
+import { SESSION_STORAGE_KEY } from '@/constants/storage';
+import { identifyUser, resetAnalyticsUser, setUserProperties, trackEvent } from '@/lib/analytics';
 import { useClientSession } from '@/utils/clientAuth';
 
 /**
@@ -27,6 +28,12 @@ export function useSyncAnalyticsUser() {
 
     if (userId) {
       identifyUser(userId);
+
+      // LoginButton에서 set한 "방금 로그인함" 플래그가 있으면 로그인 직후 1회만 complete_login 발사
+      if (sessionStorage.getItem(SESSION_STORAGE_KEY.justLoggedIn)) {
+        trackEvent('complete_login');
+        sessionStorage.removeItem(SESSION_STORAGE_KEY.justLoggedIn);
+      }
     } else {
       resetAnalyticsUser();
     }

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -28,6 +28,24 @@ export const trackEvent = (eventName: string, properties?: Record<string, any>) 
   }
 };
 
+// 로그인한 사용자를 Mixpanel에 식별 (사용자 속성 설정의 전제 조건)
+export const identifyUser = (userId: string) => {
+  if (!isProd || !userId) return;
+  mixpanel.identify(userId);
+};
+
+// Mixpanel 사용자 속성(People) 설정
+export const setUserProperties = (properties: Record<string, any>) => {
+  if (!isProd) return;
+  mixpanel.people.set(properties);
+};
+
+// 로그아웃 시 사용자 식별 해제
+export const resetAnalyticsUser = () => {
+  if (!isProd) return;
+  mixpanel.reset();
+};
+
 // 페이지 뷰 추적을 위한 함수
 export const trackPageView = (url: string) => {
   if (!isProd) return;


### PR DESCRIPTION
## 작업 내용

Mixpanel 사용자 식별/속성 + 주요 이벤트 로깅을 추가합니다. (이벤트 정의: Notion Taxonomy 기준)

### 사용자 속성
- 로그인 사용자를 `identify`하고, 포인트 잔액을 사용자 속성(People)으로 **항상 동기화** (`useSyncAnalyticsUser`)
- 기존에 없던 `mixpanel.identify` / `people.set` 기반 마련 (`analytics.ts`)
- provider 바깥(`layout.tsx`)의 중복 `<Monitoring />` 제거 → GA/Mixpanel 이중 초기화 해소

### 이벤트
- `complete_login` — 로그인 직후 sessionStorage 플래그 기반으로 `useSyncAnalyticsUser`에서 1회 발사 (프로퍼티 없음)
  - `redirect:true`로 즉시 페이지 전환되므로 플래그 방식 사용
- `click_auction_buy` — 경매 Buy 성공 시 / `pet_name`, `pet_price`, `pet_level`, `pet_grade`, `seller_id`
- `click_pet_sell` — 펫 판매 성공 시 / `pet_name`, `pet_price`, `pet_grade`, `pet_level`, `page_name`, `location`, `seller_id`
  - ① mypage(`dropPet`, 100P) → `page_name=mypage`, `location=my_pet`
  - ② auction(`useRegisterProduct`) → `page_name=shop`, `location=auction_my_pet`

## 변경 파일
- `lib/analytics.ts`, `hooks/useSyncAnalyticsUser.ts`, `components/Global/Monitoring.tsx`, `app/[locale]/layout.tsx`
- `constants/storage.ts`, `app/[locale]/auth/LoginButton.tsx`
- `app/[locale]/shop/_auction/ProductTable.tsx`, `app/[locale]/shop/_auction/SellSection/SellInputRow.tsx`
- `app/[locale]/mypage/my-pet/SelectedPetTable.tsx`

## 체크리스트
- [x] 사용자 포인트 속성 동기화
- [x] `click_auction_buy` (스펙 프로퍼티로 정렬)
- [x] `complete_login`
- [x] `click_pet_sell` (mypage + auction)

## 검증
- 변경한 web 파일 type-check 통과 (남은 에러는 본 변경과 무관한 기존/환경 이슈: overlay-kit 등 미설치)
- pre-push 훅의 webview type-check 실패도 본 변경과 무관 (web 전용 변경)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정 및 개선**
  * 사용자 로그인, 반려동물 판매, 경매 구매 등 주요 작업에 대한 이벤트 추적 기능이 강화되었습니다.
  * 사용자 분석 데이터 동기화가 개선되어 더욱 정확한 사용자 식별이 가능해졌습니다.
  * 애플리케이션 모니터링 시스템이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->