### PR TITLE
fix: 마이페이지 Farm Type 복사 버튼 가시성 및 펫 머지 모달 UI 개선

### DIFF
--- a/apps/web/src/app/[locale]/mypage/(github-custom)/FarmType.tsx
+++ b/apps/web/src/app/[locale]/mypage/(github-custom)/FarmType.tsx
@@ -49,12 +49,15 @@ export function FarmType() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              background: 'white.white_25',
+              background: 'black.black_50',
               borderRadius: '6px',
               position: 'absolute',
               top: '12px',
               right: '12px',
               color: 'white',
+              cursor: 'pointer',
+              transition: 'background 0.2s',
+              _hover: { background: 'black.black_75' },
             })}
             onClick={onLinkCopy}
           >

--- a/apps/web/src/app/[locale]/mypage/my-pet/(merge)/MergePreview.tsx
+++ b/apps/web/src/app/[locale]/mypage/my-pet/(merge)/MergePreview.tsx
@@ -34,25 +34,25 @@ export const MergePreview = ({ materialPersona, targetPersona }: MergePersonaPro
     <div className={containerStyle}>
       <div className={itemContainerStyle}>
         {targetPersona ? (
-          <PersonaBanner level={targetPersona.level} personaType={targetPersona.type} />
+          <PersonaBanner level={targetPersona.level} personaType={targetPersona.type} size="small" />
         ) : (
-          <PersonaBannerUnknown />
+          <PersonaBannerUnknown size="small" />
         )}
         <PlusIcon width={24} height={24} className={iconStyle} color="#FFFFFFBF" />
 
         {materialPersona ? (
-          <PersonaBanner level={materialPersona.level} personaType={materialPersona.type} />
+          <PersonaBanner level={materialPersona.level} personaType={materialPersona.type} size="small" />
         ) : (
-          <PersonaBannerUnknown />
+          <PersonaBannerUnknown size="small" />
         )}
 
         <EqualIcon width={24} height={24} className={iconStyle} color="#FFFFFFBF" />
 
         <ResultItemAnimation isVisible={Boolean(resultPersona)} key={resultPersona?.id}>
           {resultPersona ? (
-            <PersonaBanner level={resultPersona.level} personaType={resultPersona.type} />
+            <PersonaBanner level={resultPersona.level} personaType={resultPersona.type} size="small" />
           ) : (
-            <PersonaBannerUnknown />
+            <PersonaBannerUnknown size="small" />
           )}
         </ResultItemAnimation>
       </div>
@@ -64,7 +64,7 @@ const containerStyle = css({
   position: 'relative',
   display: 'flex',
   justifyContent: 'center',
-  padding: '32px 32px 12px',
+  padding: '16px 0 8px',
   overflow: 'hidden',
   minHeight: 'fit-content',
 
@@ -81,7 +81,7 @@ const itemContainerStyle = flex({
 });
 
 const iconStyle = css({
-  marginBottom: '34px',
+  marginBottom: '24px',
 });
 
 const flashEffectStyle = css({

--- a/apps/web/src/app/[locale]/mypage/my-pet/_components/PersonaBanner.tsx
+++ b/apps/web/src/app/[locale]/mypage/my-pet/_components/PersonaBanner.tsx
@@ -2,22 +2,38 @@ import { css, cx } from '_panda/css';
 
 import { getPersonaImage } from '@/utils/image';
 
-export function PersonaBanner({ level, personaType }: { level: number | string; personaType: string }) {
+type PersonaBannerSize = 'default' | 'small';
+
+export function PersonaBanner({
+  level,
+  personaType,
+  size = 'default',
+}: {
+  level: number | string;
+  personaType: string;
+  size?: PersonaBannerSize;
+}) {
+  const isSmall = size === 'small';
   return (
-    <div className={itemStyle}>
+    <div className={cx(itemStyle, isSmall && itemSmallStyle)}>
       <div className={mergeItemStyle}>
-        <img src={getPersonaImage(personaType)} alt={personaType} className={imageStyle} />
+        <img
+          src={getPersonaImage(personaType)}
+          alt={personaType}
+          className={cx(imageStyle, isSmall && imageSmallStyle)}
+        />
       </div>
-      <div className={levelTextStyle}>Level {level}</div>
+      <div className={cx(levelTextStyle, isSmall && levelTextSmallStyle)}>Level {level}</div>
     </div>
   );
 }
 
-export function PersonaBannerUnknown() {
+export function PersonaBannerUnknown({ size = 'default' }: { size?: PersonaBannerSize }) {
+  const isSmall = size === 'small';
   return (
-    <div className={itemStyle}>
-      <img src="/mypage/merge/merge-empty.svg" alt="empty" className={imageStyle} />
-      <div className={cx(levelTextStyle, levelEmptyTextStyle)}>Level ?</div>
+    <div className={cx(itemStyle, isSmall && itemSmallStyle)}>
+      <img src="/mypage/merge/merge-empty.svg" alt="empty" className={cx(imageStyle, isSmall && imageSmallStyle)} />
+      <div className={cx(levelTextStyle, levelEmptyTextStyle, isSmall && levelTextSmallStyle)}>Level ?</div>
     </div>
   );
 }
@@ -38,10 +54,19 @@ const itemStyle = css({
   padding: '8px',
 });
 
+const itemSmallStyle = css({
+  padding: '6px',
+});
+
 const imageStyle = css({
   objectFit: 'contain',
   width: '120px',
   height: '120px',
+});
+
+const imageSmallStyle = css({
+  width: '72px',
+  height: '72px',
 });
 
 const levelTextStyle = css({
@@ -49,6 +74,11 @@ const levelTextStyle = css({
   marginTop: '12px',
   textStyle: 'glyph18.bold',
   color: 'white.white_100',
+});
+
+const levelTextSmallStyle = css({
+  marginTop: '6px',
+  textStyle: 'glyph14.bold',
 });
 
 const levelEmptyTextStyle = css({

--- a/apps/web/src/app/[locale]/mypage/my-pet/_components/SelectPersonaList.tsx
+++ b/apps/web/src/app/[locale]/mypage/my-pet/_components/SelectPersonaList.tsx
@@ -81,15 +81,21 @@ const listSectionTitleStyle = css({
 
 const flexOverflowStyle = cx(
   css({
-    display: 'flex',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, 80px)',
+    gridAutoRows: '80px',
+    justifyContent: 'flex-start',
     overflowY: 'auto',
     overflowX: 'hidden',
     width: '100%',
-    gap: '4px',
+    gap: '8px',
     height: '100%',
     minHeight: '0',
-    flexWrap: 'wrap',
     maxHeight: 'calc(100% - 24px)',
+    _mobile: {
+      gridTemplateColumns: 'repeat(auto-fill, 52px)',
+      gridAutoRows: '52px',
+    },
   }),
   customScrollStyle,
 );


### PR DESCRIPTION
## 개요
마이페이지의 두 가지 UI 문제를 수정합니다.

## 변경 사항

### 1. Farm Type 복사 버튼 가시성 수정
- 흰색 반투명 배경(`white_25`) + 흰색 아이콘이라 흰색 카드 위에서 버튼이 묻혀 보이지 않던 문제 수정
- 어두운 반투명 오버레이(`black_50`, hover `black_75`)로 변경 — 배경 색을 바꿔도 대비 유지
- `cursor: pointer` 및 hover transition 추가

### 2. 펫 머지 모달 UI 개선
- **펫 목록 그리드 배치**: flex(`flexWrap: wrap`이 있으나 각 아이템 버튼이 `width:100%`라 한 줄씩 수직으로 쌓이던 문제) → CSS grid(`repeat(auto-fill, 80px)`, 모바일 52px)로 변경해 격자로 wrap
- **상단 영역 축소**: 미리보기가 모달 높이 대부분을 차지해 선택 목록이 좁던 문제 해결
  - `PersonaBanner`에 `size` prop 추가 (기본값 유지 → Evolution 화면 영향 없음)
  - `MergePreview`에 `size="small"` 적용 + 컨테이너 패딩/아이콘 마진 축소

## 영향 범위
- 변경은 마이페이지 merge/farm 관련 컴포넌트로 한정
- 공용 `Dialog`/`PersonaItem`은 수정하지 않음
- `PersonaBanner` 변경은 prop 추가(하위호환)

## 검증
- `pnpm --filter @gitanimals/web type-check` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일 개선**
  * 복사 링크 버튼의 시각적 피드백 개선
  * 개인 배너 컴포넌트의 크기 옵션 추가 (기본값/소형)
  * 배너 미리보기 화면의 간격 및 레이아웃 최적화
  * 개인 선택 목록의 레이아웃 구조 개선으로 더 나은 화면 배치 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->