### PR TITLE
fix(shop): 10펫 뽑기 연출 어색함 3건 수정

### DIFF
--- a/apps/web/src/app/[locale]/shop/_petGotcha/CardPackGame.tsx
+++ b/apps/web/src/app/[locale]/shop/_petGotcha/CardPackGame.tsx
@@ -22,6 +22,9 @@ const TIER_RANK: Record<AnimalTierType, number> = { EX: 0, S_PLUS: 1, A_PLUS: 2,
 const tierOf = (p: GotchaResult) => getAnimalTierInfo(Number(p.dropRate.replace('%', '')));
 const isRare = (p: GotchaResult) => tierOf(p) === 'EX' || tierOf(p) === 'S_PLUS';
 
+// 회전(0.5s)이 끝나고 한 박자 뒤 — 이때 광채/컨페티로 레어를 강조한다
+const RARE_EMPHASIS_DELAY_MS = 500;
+
 type Phase = 'pack' | 'opening' | 'revealing' | 'finale' | 'done';
 
 interface Props {
@@ -82,17 +85,23 @@ export function CardPackGame({ onOpen, results, onClose, onBusyChange }: Props) 
         return next;
       });
       const rare = isRare(res[i]);
-      if (rare) {
-        doShake();
-        fireConfetti({
-          particleCount: 50,
-          spread: 70,
-          startVelocity: 38,
-          origin: { y: 0.5 },
-          colors: [TIER_GLOW[tierOf(res[i])], '#ffffff'],
-        });
+      if (!rare) {
+        await wait(150);
+        if (skippedRef.current) return;
+        continue;
       }
-      await wait(rare ? 340 : 150);
+      // 앞면이 보인 뒤에 강조 — 뒷면 상태에서 글로우/컨페티가 터지면 등급이 미리 새어나간다
+      await wait(RARE_EMPHASIS_DELAY_MS);
+      if (skippedRef.current) return;
+      doShake();
+      fireConfetti({
+        particleCount: 50,
+        spread: 70,
+        startVelocity: 38,
+        origin: { y: 0.5 },
+        colors: [TIER_GLOW[tierOf(res[i])], '#ffffff'],
+      });
+      await wait(340);
       if (skippedRef.current) return;
     }
 
@@ -149,23 +158,35 @@ export function CardPackGame({ onOpen, results, onClose, onBusyChange }: Props) 
       className="relative flex h-full min-h-[560px] w-full flex-col items-center justify-center overflow-hidden"
       onClick={handleStageClick}
     >
-      {/* 닫힌 덱(×10) */}
+      {/* 닫힌 덱(×10) — 응답 대기(opening) 동안에도 남겨 정적인 빈 화면을 만들지 않는다 */}
       <AnimatePresence>
-        {phase === 'pack' && (
+        {(phase === 'pack' || phase === 'opening') && (
           <motion.button
             type="button"
             key="deck"
             className="relative z-10"
+            disabled={phase === 'opening'}
             onClick={(e) => {
               e.stopPropagation();
               openPack();
             }}
             aria-label="open pack"
             initial={{ scale: 0.9, opacity: 0 }}
-            animate={reduce ? { scale: 1, opacity: 1 } : { scale: 1, opacity: 1, y: [0, -10, 0] }}
+            animate={
+              reduce
+                ? { scale: 1, opacity: 1 }
+                : phase === 'opening'
+                  ? { scale: [1, 1.06, 1], opacity: 1, rotate: [0, -2, 2, 0] }
+                  : { scale: 1, opacity: 1, y: [0, -10, 0] }
+            }
             exit={{ scale: 1.15, opacity: 0, transition: { duration: 0.2 } }}
-            transition={{ y: { duration: 1.8, repeat: Infinity, ease: 'easeInOut' }, default: { duration: 0.3 } }}
-            whileHover={{ scale: 1.05 }}
+            transition={{
+              y: { duration: 1.8, repeat: Infinity, ease: 'easeInOut' },
+              scale: phase === 'opening' ? { duration: 0.6, repeat: Infinity } : { duration: 0.3 },
+              rotate: { duration: 0.6, repeat: Infinity },
+              default: { duration: 0.3 },
+            }}
+            whileHover={phase === 'pack' ? { scale: 1.05 } : undefined}
           >
             <CardDeck />
           </motion.button>
@@ -173,7 +194,7 @@ export function CardPackGame({ onOpen, results, onClose, onBusyChange }: Props) 
       </AnimatePresence>
 
       {/* 개봉 순간 — 중앙에서 부드럽게 퍼지는 빛 (전체 화이트 플래시 대신) */}
-      {phase === 'opening' && (
+      {phase === 'revealing' && (
         <motion.div
           className="pointer-events-none absolute left-1/2 top-1/2 z-20 h-[340px] w-[340px] -translate-x-1/2 -translate-y-1/2"
           initial={{ opacity: 0.6, scale: 0.2 }}
@@ -183,8 +204,8 @@ export function CardPackGame({ onOpen, results, onClose, onBusyChange }: Props) 
         />
       )}
 
-      {/* 카드 그리드 */}
-      {phase !== 'pack' && (
+      {/* 카드 그리드 — 결과 도착 후에만 펼친다 */}
+      {phase !== 'pack' && phase !== 'opening' && (
         <motion.div className="z-10 grid grid-cols-5 gap-[14px] px-4 mobile:gap-[6px]" animate={shake}>
           {Array.from({ length: 10 }).map((_, i) => (
             <PackCard
@@ -209,8 +230,10 @@ export function CardPackGame({ onOpen, results, onClose, onBusyChange }: Props) 
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           >
+            {/* 스크림 — 없으면 확대 카드가 그리드에 파묻혀 '잘못 놓인 카드'처럼 보인다 */}
+            <div className="absolute inset-0 bg-black/75" />
             <motion.div
-              className="relative w-[260px] max-w-[70vw]"
+              className="relative w-[320px] max-w-[75vw]"
               initial={{ scale: 0.3, y: 40, opacity: 0 }}
               animate={{ scale: 1, y: 0, opacity: 1 }}
               transition={{ type: 'spring', stiffness: 140, damping: 13 }}
@@ -307,6 +330,8 @@ function PackCard({
           className="pointer-events-none absolute -inset-1.5 -z-10 rounded-2xl"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
+          // 뒤집힘이 끝나고 한 박자 뒤에 번지도록 — 뒷면에서 광채가 새면 등급이 미리 노출된다
+          transition={{ duration: 0.35, delay: isBest ? 0 : 0.45 }}
           style={{
             boxShadow: `0 0 ${isBest ? 28 : 18}px ${isBest ? 8 : 4}px ${TIER_GLOW[tier]}`,
             background: `${TIER_GLOW[tier]}22`,


### PR DESCRIPTION
## 배경

10펫 뽑기(`CardPackGame`) 동작이 어색하다는 리포트를 받아, dev 서버를 띄우고 브라우저에서 프레임 단위로 캡처해 원인을 특정했습니다.

## 발견한 문제와 수정

### 1. 응답 대기 중 화면이 죽어 있음
`opening`(API 호출 중) 단계에서 이미 카드 10장이 전부 펼쳐져, 500ms 만에 정지된 뒷면 그리드만 남고 응답이 올 때까지 아무 움직임이 없었습니다. 지연 3초로 재현하니 2.5초간 완전 정지.

→ 덱을 대기 동안 유지(맥박 + 흔들림)하고, **결과가 도착한 뒤에만** 카드를 펼치도록 변경. API가 느려도 빈 화면이 생기지 않습니다.

### 2. 뒤집기 전에 등급이 새어나감
`isFlipped`가 회전 시작과 동시에 `true`가 되어, **카드가 아직 뒷면인 상태에서 광채와 컨페티가 터졌습니다.** (캡처에 물음표 뒷면 카드가 보라색 광채에 둘러싸인 채로 찍힘)

→ 레어 강조를 회전 완료 후로 이동(`RARE_EMPHASIS_DELAY_MS = 500`), 광채는 거기서 한 박자 더 뒤(`delay: 0.45s`)에 번지도록 조정.

### 3. 피날레 카드가 그리드에 파묻힘
확대 카드가 260px(그리드 카드 116px)뿐이고 뒤 그리드가 `opacity: 0.35`로 살아 있어, 히어로 연출이 아니라 "잘못 놓인 카드"처럼 보였습니다.

→ `bg-black/75` 스크림을 깔고 카드를 320px로 확대.

## 검증

- 브라우저에서 지연 800ms / 3000ms 두 조건으로 전체 시퀀스 재생 확인
- 진행 중 탭 = 건너뛰기 정상 동작 확인
- `pnpm --filter @gitanimals/web type-check` 통과

미검증: reduced-motion 경로는 코드 분기만 확인했고 브라우저 재현은 하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)